### PR TITLE
chore: enable goconst detection for function call arguments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,8 @@ linters:
     goconst:
       min-len: 3
       min-occurrences: 3
+      ignore-calls: false
+      ignore-string-values: "%[a-zA-Z]"
     lll:
       line-length: 120
     dupl:
@@ -85,6 +87,8 @@ linters:
     rules:
       - path: (_test\.go|testutil/)
         linters: [gosec]
+      - path: _test\.go
+        linters: [goconst]
       - path: _test\.go
         linters: [gocognit]
       - path: _test\.go


### PR DESCRIPTION
## Issue
N/A

## Summary
- Disable goconst `ignore-calls` (default `true`) so repeated string literals in function arguments are detected
- Add `ignore-string-values: "%[a-zA-Z]"` regex to skip format strings (idiomatic Go, not worth extracting)
- Exclude test files from goconst — tests intentionally repeat strings for readability

## Test Plan
- [x] Linter passes (`make lint`)
- [x] All tests pass (`make test`)

## Notes
goconst defaults `ignore-calls: true`, which silently skips all string literals used as function arguments — the most common location for duplicated strings (HTTP headers, error messages, SQL queries). This change enables detection while filtering out format strings and test noise.