### PR TITLE
feat: add nolateconst analyzer to panenlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,7 @@ linters:
     custom:
       panenlint:
         type: "module"
-        description: "Panen custom lint rules (funcname, maxparams, nolocalstruct, nolateexport)"
+        description: "Panen custom lint rules (funcname, maxparams, nolateconst, nolocalstruct, nolateexport)"
     decorder:
       dec-order:
         - type

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,9 +64,11 @@ make release-check     # Validate VERSION against wails.json productVersion
 
 ## Custom Linter (panenlint)
 
-`tools/lint/` contains three analyzers built as a golangci-lint v2 module plugin:
+`tools/lint/` contains five analyzers built as a golangci-lint v2 module plugin:
 
+- **funcname**: forbids underscores in function names
 - **maxparams**: forbids functions with >7 parameters
+- **nolateconst**: forbids package-level const/var declarations after function declarations
 - **nolocalstruct**: forbids named struct declarations inside function bodies
 - **nolateexport**: forbids exported standalone functions after unexported ones
 

--- a/backend/domain/valuation/enum.go
+++ b/backend/domain/valuation/enum.go
@@ -11,6 +11,15 @@ const (
 	RiskAggressive   RiskProfile = "AGGRESSIVE"
 )
 
+// Verdict indicates whether a stock is undervalued, fair, or overvalued.
+type Verdict string
+
+const (
+	VerdictUndervalued Verdict = "UNDERVALUED"
+	VerdictFair        Verdict = "FAIR"
+	VerdictOvervalued  Verdict = "OVERVALUED"
+)
+
 // ParseRiskProfile converts a string to a RiskProfile enum value.
 func ParseRiskProfile(s string) (RiskProfile, error) {
 	switch s {
@@ -24,12 +33,3 @@ func ParseRiskProfile(s string) (RiskProfile, error) {
 		return "", fmt.Errorf("%w: %s", ErrInvalidRisk, s)
 	}
 }
-
-// Verdict indicates whether a stock is undervalued, fair, or overvalued.
-type Verdict string
-
-const (
-	VerdictUndervalued Verdict = "UNDERVALUED"
-	VerdictFair        Verdict = "FAIR"
-	VerdictOvervalued  Verdict = "OVERVALUED"
-)

--- a/backend/infra/database/watchlist_repo.go
+++ b/backend/infra/database/watchlist_repo.go
@@ -19,7 +19,15 @@ const (
 		FROM watchlists WHERE profile_id = ? ORDER BY name`
 	watchlistUpdate = `UPDATE watchlists SET name = ?, updated_at = ?
 		WHERE id = ?`
-	watchlistDelete = `DELETE FROM watchlists WHERE id = ?`
+	watchlistDelete  = `DELETE FROM watchlists WHERE id = ?`
+	watchlistItemAdd = `INSERT INTO watchlist_items
+		(id, watchlist_id, ticker, created_at)
+		VALUES (?, ?, ?, ?)`
+	watchlistItemRemove            = `DELETE FROM watchlist_items WHERE watchlist_id = ? AND ticker = ?`
+	watchlistItemListByWatchlistID = `SELECT id, watchlist_id, ticker, created_at
+		FROM watchlist_items WHERE watchlist_id = ? ORDER BY ticker`
+	watchlistItemExists = `SELECT COUNT(*) FROM watchlist_items
+		WHERE watchlist_id = ? AND ticker = ?`
 )
 
 // WatchlistRepo implements watchlist.Repository.
@@ -102,17 +110,6 @@ func (r *WatchlistRepo) Delete(ctx context.Context, id string) error {
 	}
 	return checkRowsAffected(res)
 }
-
-const (
-	watchlistItemAdd = `INSERT INTO watchlist_items
-		(id, watchlist_id, ticker, created_at)
-		VALUES (?, ?, ?, ?)`
-	watchlistItemRemove            = `DELETE FROM watchlist_items WHERE watchlist_id = ? AND ticker = ?`
-	watchlistItemListByWatchlistID = `SELECT id, watchlist_id, ticker, created_at
-		FROM watchlist_items WHERE watchlist_id = ? ORDER BY ticker`
-	watchlistItemExists = `SELECT COUNT(*) FROM watchlist_items
-		WHERE watchlist_id = ? AND ticker = ?`
-)
 
 // WatchlistItemRepo implements watchlist.ItemRepository.
 type WatchlistItemRepo struct {

--- a/tools/lint/nolateconst/analyzer.go
+++ b/tools/lint/nolateconst/analyzer.go
@@ -1,0 +1,41 @@
+// Package nolateconst defines an analyzer that forbids package-level const
+// and var declarations that appear after any function or method declaration.
+// All constants and variables should be grouped before functions.
+package nolateconst
+
+import (
+	"go/ast"
+	"go/token"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// Analyzer reports package-level const/var declarations that appear after function declarations.
+var Analyzer = &analysis.Analyzer{
+	Name: "nolateconst",
+	Doc:  "forbids package-level const/var declarations after function declarations",
+	Run:  run,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	for _, file := range pass.Files {
+		seenFunc := false
+		for _, decl := range file.Decls {
+			switch d := decl.(type) {
+			case *ast.FuncDecl:
+				seenFunc = true
+			case *ast.GenDecl:
+				if !seenFunc {
+					continue
+				}
+				switch d.Tok {
+				case token.CONST:
+					pass.Reportf(d.TokPos, "const declaration after function declaration")
+				case token.VAR:
+					pass.Reportf(d.TokPos, "var declaration after function declaration")
+				}
+			}
+		}
+	}
+	return nil, nil
+}

--- a/tools/lint/nolateconst/analyzer_test.go
+++ b/tools/lint/nolateconst/analyzer_test.go
@@ -1,0 +1,14 @@
+package nolateconst_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/lugassawan/panen/tools/lint/nolateconst"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, nolateconst.Analyzer, "example")
+}

--- a/tools/lint/nolateconst/testdata/src/example/example.go
+++ b/tools/lint/nolateconst/testdata/src/example/example.go
@@ -1,0 +1,27 @@
+package example
+
+const beforeConst = 1 // OK - const before any func
+
+var beforeVar = 2 // OK - var before any func
+
+type T struct{} // OK - type declarations are fine anywhere
+
+func exported() {} // OK - first func
+
+func (t T) method() {} // OK - method also sets seenFunc
+
+const afterConst = 3 // want `const declaration after function declaration`
+
+var afterVar = 4 // want `var declaration after function declaration`
+
+const ( // want `const declaration after function declaration`
+	groupedA = 5
+	groupedB = 6
+)
+
+var ( // want `var declaration after function declaration`
+	groupedC = 7
+	groupedD = 8
+)
+
+func another() {} // OK - func after func is fine

--- a/tools/lint/plugin.go
+++ b/tools/lint/plugin.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lugassawan/panen/tools/lint/funcname"
 	"github.com/lugassawan/panen/tools/lint/maxparams"
+	"github.com/lugassawan/panen/tools/lint/nolateconst"
 	"github.com/lugassawan/panen/tools/lint/nolateexport"
 	"github.com/lugassawan/panen/tools/lint/nolocalstruct"
 )
@@ -25,6 +26,7 @@ func (p *plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
 	return []*analysis.Analyzer{
 		funcname.Analyzer,
 		maxparams.Analyzer,
+		nolateconst.Analyzer,
 		nolocalstruct.Analyzer,
 		nolateexport.Analyzer,
 	}, nil


### PR DESCRIPTION
## Issue

N/A

## Summary

- Add `nolateconst` analyzer that forbids package-level `const`/`var` declarations after any function or method declaration
- Fix two existing violations caught by the new analyzer (`backend/domain/valuation/enum.go`, `backend/infra/database/watchlist_repo.go`)
- Register analyzer in `plugin.go`, update `.golangci.yml` description, and document in `CLAUDE.md`

## Test Plan

- [x] Linter passes (`make lint`)
- [x] All Go tests pass (`make test-go`), including new `nolateconst` analyzer tests
- [x] All frontend tests pass (`make test-frontend`)
- [x] Formatting clean (`make fmt`)

## Notes

- Follows the same pattern as `nolateexport` analyzer: iterate `file.Decls`, track a boolean flag (`seenFunc`), report violations
- Test fixture covers: const/var before func (OK), const/var after func (ERROR), grouped blocks after func (ERROR), type declarations don't trigger, methods set `seenFunc`
- Also fixed pre-existing `funcname` omission from the CLAUDE.md analyzer list