### PR TITLE
docs: document all commit and PR prefix conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,14 +53,14 @@ make release-check     # Validate VERSION against wails.json productVersion
 
 ## Conventions
 
-- **Commits**: `type: description` only — no scopes, no `!` (enforced by `.githooks/commit-msg`)
+- **Commits**: `type: description` — valid types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `style`, `perf`, `build`, `ci`, `revert` (enforced by `.githooks/commit-msg`; no scopes, no `!`)
 - **Direct commits to main/master are blocked** by the pre-commit hook
 - **Go**: Standard library style, `gofmt` formatting, tab indentation
 - **Frontend**: 2-space indentation, double quotes, semicolons (Biome enforced)
 - **Branches**: `feat/`, `fix/`, `chore/` prefixes
 - **Worktrees**: Only use git worktrees when running parallel agents on independent tasks — never for single sequential work or when targeting main/master (pre-commit hook blocks direct commits)
 - **Code review**: Prefer running code review before creating PRs (e.g., via available code-review skills or agents)
-- **PRs**: Title uses `type: description` (same as commits); body follows `.github/pull_request_template.md`
+- **PRs**: Title uses `type: description` (same types as commits); body follows `.github/pull_request_template.md`
 
 ## Custom Linter (panenlint)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,21 +111,27 @@ chore/update-dependencies
 
 ### Commits
 
-Conventional Commits format, strictly `type: description`:
+Conventional Commits format, strictly `type: description`. The commit-msg hook enforces these types:
 
-```
-feat: add portfolio summary page
-fix: correct dividend yield calculation
-chore: update Go dependencies
-docs: add API design document
-refactor: extract price service
-test: add screener filter tests
-```
+| Type | When to use | Example |
+|------|-------------|---------|
+| `feat` | New user-facing feature or capability | `feat: add portfolio summary page` |
+| `fix` | Bug correction | `fix: correct dividend yield calculation` |
+| `chore` | Maintenance, dependency updates, config tweaks | `chore: update Go dependencies` |
+| `docs` | Documentation only (README, CLAUDE.md, comments) | `docs: add API design document` |
+| `refactor` | Code restructuring with no behavior change | `refactor: extract price service` |
+| `test` | Adding or updating tests only | `test: add screener filter tests` |
+| `style` | Formatting, whitespace, semicolons (no logic change) | `style: fix indentation in app.css` |
+| `perf` | Performance improvement | `perf: cache stock price lookups` |
+| `build` | Build system or tooling changes (Wails, Vite, Makefile) | `build: upgrade Vite to v8` |
+| `ci` | CI/CD pipeline changes (GitHub Actions, workflows) | `ci: add release workflow` |
+| `revert` | Reverting a previous commit | `revert: revert portfolio page changes` |
 
 No scopes or breaking change markers. Direct commits to `main` are blocked.
 
 ### Pull Requests
 
+- Title uses `type: description` format (same types as commits above)
 - One logical change per PR
 - Ensure `make lint` and `make test` pass before opening
 - Fill in the PR template (issue link, summary, test plan)


### PR DESCRIPTION
## Issue
N/A

## Summary
- Add full 11-type reference table to CONTRIBUTING.md commits section (was only showing 6 examples)
- Add PR title format requirement to CONTRIBUTING.md pull requests section
- List all valid commit types inline in CLAUDE.md conventions section

## Test Plan
- [x] All 11 types in docs match `.githooks/commit-msg` regex (verified)
- [x] No code changes — documentation only

## Notes
The commit-msg hook enforces `feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert` but docs were incomplete. Now CLAUDE.md and CONTRIBUTING.md are consistent with each other and with the hook.