### PR TITLE
docs: add manual testing section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ make release-check     # Validate VERSION against wails.json productVersion
 ### Manual Testing
 
 - Start the app with `make dev` — this launches the native Wails window and the Vite dev server at `http://localhost:5173`
-- Use **Playwright MCP** tools (`mcp__plugin_playwright_playwright__*`) against `http://localhost:5173` for visual/UI verification
+- Use **Claude Chrome extension** tools (`mcp__claude-in-chrome__*`) for visual/UI verification; fall back to **Playwright MCP** tools (`mcp__plugin_playwright_playwright__*`) if the Chrome extension is unavailable
 - Wails runtime bindings are unavailable in browser — backend-dependent features (stock lookup, portfolio actions) won't work; use for layout, navigation, theming, and interaction verification
 - Include manual verification steps in PR test plans when changes affect UI
 


### PR DESCRIPTION
## Issue
N/A

## Summary
- Add `### Manual Testing` subsection to the Testing section of CLAUDE.md
- Documents the established pattern of using Playwright MCP tools against the Vite dev server (`localhost:5173`) for visual/UI verification
- Notes Wails runtime limitation in browser mode and when to include manual verification in PR test plans

## Test Plan
- [x] Linter passes (`make lint`)
- [x] New section is correctly placed between Frontend E2E and Wails Mock Pattern subsections
- [x] No duplicate content with existing sections

## Notes
Placement follows the natural progression: automated tests → manual verification → test utilities.