### PR TITLE
docs: document Wails dev server URL for full backend testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,9 +98,10 @@ make release-check     # Validate VERSION against wails.json productVersion
 
 ### Manual Testing
 
-- Start the app with `make dev` — this launches the native Wails window and the Vite dev server at `http://localhost:5173`
+- Start the app with `make dev` — this launches the native Wails window, the Vite dev server at `http://localhost:5173`, and the Wails dev server at `http://localhost:34115`
+- **Use `http://localhost:34115` for full testing** — Wails runtime is injected, so backend-dependent features (stock lookup, portfolio actions) work in the browser
+- Use `http://localhost:5173` only for frontend-only checks (layout, theming, interactions) — Wails runtime bindings are **not** available on this port
 - Use **Claude Chrome extension** tools (`mcp__claude-in-chrome__*`) for visual/UI verification; fall back to **Playwright MCP** tools (`mcp__plugin_playwright_playwright__*`) if the Chrome extension is unavailable
-- Wails runtime bindings are unavailable in browser — backend-dependent features (stock lookup, portfolio actions) won't work; use for layout, navigation, theming, and interaction verification
 - Include manual verification steps in PR test plans when changes affect UI
 
 ### Wails Mock Pattern


### PR DESCRIPTION
## Issue
N/A

## Summary
- Update CLAUDE.md Manual Testing section to document both dev server URLs: Vite (`localhost:5173`) and Wails (`localhost:34115`)
- Recommend `localhost:34115` for full testing with backend bindings injected
- Clarify that `localhost:5173` is frontend-only (no Wails runtime)

## Test Plan
- [x] Linter passes (`make lint`)
- [x] Read updated section to confirm accuracy

## Notes
The Wails dev server on `:34115` proxies to Vite but injects the Wails runtime bridge, enabling Go↔JS bindings in the browser. Previously the docs incorrectly stated that Wails runtime was unavailable in the browser.