### PR TITLE
docs: update project structure and conventions after PR #62

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ make release-check     # Validate VERSION against wails.json productVersion
 - **Go**: Standard library style, `gofmt` formatting, tab indentation
 - **Frontend**: 2-space indentation, double quotes, semicolons (Biome enforced)
 - **Branches**: `feat/`, `fix/`, `chore/` prefixes
-- **Worktrees**: Only use git worktrees when running parallel agents on independent tasks — never for single sequential work or when targeting main/master (pre-commit hook blocks direct commits)
+- **Worktrees**: Only use git worktrees when running parallel agents on independent tasks — never for single sequential work or when targeting main/master (pre-commit hook blocks direct commits). After work is done, clean up with `git worktree remove <path>` (use `--force` if it has uncommitted changes) and `git branch -D <branch>` to delete the worktree branch
 - **Code review**: Prefer running code review before creating PRs (e.g., via available code-review skills or agents)
 - **PRs**: Title uses `type: description` (same types as commits); body follows `.github/pull_request_template.md`
 
@@ -140,7 +140,7 @@ Full reference: `docs/design-system.md`
 
 ### Components
 
-Reusable components in `frontend/src/lib/components/`: Button, Badge, Alert, ThemeToggle, ModeTabs, StockCard
+Reusable components in `frontend/src/lib/components/`: Button, Input, Select, Badge, Alert, ThemeToggle, ModeTabs, StockCard, SyncIndicator
 
 ### Key Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,9 +139,9 @@ No scopes or breaking change markers. Direct commits to `main` are blocked.
 ## Project Structure
 
 ```
-backend/app/       Go application logic (Wails-bound methods)
-frontend/src/      Svelte 5 components and TypeScript
-tools/lint/        Custom golangci-lint analyzers
-build/             Build assets
-docs/plans/        Design documents
+backend/              Go backend (presenter, domain, usecase, infra layers)
+frontend/src/         Svelte 5 app (pages/, lib/components/, stores, utils)
+tools/lint/           Custom golangci-lint analyzers
+build/                Build assets
+docs/plans/           Design documents
 ```

--- a/README.md
+++ b/README.md
@@ -70,8 +70,11 @@ panen/
 │   ├── usecase/       # Application services (orchestration + validation)
 │   └── infra/         # Database, scraper, platform implementations
 ├── frontend/src/
-│   ├── assets/fonts/  # Self-hosted WOFF2 font files
-│   └── ...            # Svelte 5 components and TypeScript
+│   ├── lib/components/  # Reusable UI primitives (Button, Input, Select, etc.)
+│   ├── components/      # Shared domain components (ConfirmDialog, Sidebar)
+│   ├── pages/           # Page components organized by domain
+│   ├── assets/fonts/    # Self-hosted WOFF2 font files
+│   └── ...              # Stores, types, utilities
 ├── tools/lint/        # Custom golangci-lint plugin (panenlint)
 ├── build/assets/      # Brand SVG assets
 ├── main.go            # Wails entry point


### PR DESCRIPTION
## Issue
Follows up on #62

## Summary
- Update frontend directory structure in README.md and CONTRIBUTING.md to reflect new `pages/`, `lib/components/`, and `components/` layout
- Add Input, Select, SyncIndicator to CLAUDE.md components list
- Add worktree cleanup instructions to CLAUDE.md conventions

## Test Plan
- [x] Linter passes (`make lint`)
- [x] Verify directory paths match actual structure

## Notes
Documentation-only change, no code modifications.