### PR TITLE
feat: auto update check with GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,13 @@ jobs:
           echo "Version $WAILS_VERSION OK"
 
       - name: Build
-        run: wails build -clean -obfuscated -platform ${{ matrix.platform }}
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          TAG_VERSION="${REF_NAME#v}"
+          LDFLAGS="-X github.com/lugassawan/panen/backend.version=${TAG_VERSION}"
+          wails build -clean -obfuscated -platform ${{ matrix.platform }} -ldflags "${LDFLAGS}"
 
       - name: Package (macOS)
         if: runner.os == 'macOS'

--- a/Makefile
+++ b/Makefile
@@ -4,24 +4,27 @@
 	coverage coverage-go coverage-frontend playwright-install \
 	release-check
 
+VERSION := $(shell jq -r '.info.productVersion' wails.json)
+LDFLAGS := -X github.com/lugassawan/panen/backend.version=$(VERSION)
+
 dev:
 	wails dev -tags dev
 
 build:
-	wails build
+	wails build -ldflags "$(LDFLAGS)"
 
 build-darwin:
-	wails build -clean -platform darwin/universal
+	wails build -clean -platform darwin/universal -ldflags "$(LDFLAGS)"
 
 build-linux:
 	@if [ "$$(uname)" != "Linux" ]; then \
 		echo "Error: Linux builds require a Linux host (GTK headers needed)." >&2; \
 		exit 1; \
 	fi
-	wails build -clean -platform linux/amd64
+	wails build -clean -platform linux/amd64 -ldflags "$(LDFLAGS)"
 
 build-windows:
-	wails build -clean -platform windows/amd64
+	wails build -clean -platform windows/amd64 -ldflags "$(LDFLAGS)"
 
 # build-all builds for platforms that support cross-compilation from the current host.
 # Linux is excluded because Wails requires native GTK headers (use CI or a Linux host).

--- a/backend/app.go
+++ b/backend/app.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lugassawan/panen/backend/domain/user"
 	brokerConfigLoader "github.com/lugassawan/panen/backend/infra/brokerconfig"
 	"github.com/lugassawan/panen/backend/infra/database"
+	"github.com/lugassawan/panen/backend/infra/github"
 	"github.com/lugassawan/panen/backend/infra/platform"
 	"github.com/lugassawan/panen/backend/infra/scraper"
 	"github.com/lugassawan/panen/backend/infra/watchlistconfig"
@@ -26,6 +27,7 @@ type App struct {
 	*presenter.WatchlistHandler
 	*presenter.RefreshHandler
 	*presenter.ChecklistHandler
+	*presenter.UpdateHandler
 	db      *database.DB
 	refresh *usecase.RefreshService
 }
@@ -107,7 +109,14 @@ func (a *App) Startup(ctx context.Context) {
 	checklistSvc := usecase.NewChecklistService(checklistRepo, portfolioRepo, holdingRepo, brokerageRepo, stockRepo)
 	a.ChecklistHandler = presenter.NewChecklistHandler(ctx, checklistSvc)
 
+	ghClient := github.NewClient()
+	updateChecker := &releaseCheckerAdapter{client: ghClient}
+	updateSvc := usecase.NewUpdateService(updateChecker, Version())
+	a.UpdateHandler = presenter.NewUpdateHandler(ctx, updateSvc, settingsRepo)
+
 	refreshSvc.Start(ctx)
+
+	go a.CheckForUpdateOnStartup()
 }
 
 // Shutdown stops background services and closes the database connection.
@@ -120,6 +129,22 @@ func (a *App) Shutdown(ctx context.Context) {
 			runtime.LogErrorf(ctx, "close database: %v", err)
 		}
 	}
+}
+
+// releaseCheckerAdapter bridges github.Client to usecase.ReleaseChecker.
+type releaseCheckerAdapter struct {
+	client *github.Client
+}
+
+func (a *releaseCheckerAdapter) LatestRelease(ctx context.Context) (*usecase.ReleaseInfo, error) {
+	rel, err := a.client.LatestRelease(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &usecase.ReleaseInfo{
+		Version:    rel.Version(),
+		ReleaseURL: rel.HTMLURL,
+	}, nil
 }
 
 func ensureDefaultUser(ctx context.Context, users user.Repository) (string, error) {

--- a/backend/domain/settings/repository.go
+++ b/backend/domain/settings/repository.go
@@ -6,4 +6,6 @@ import "context"
 type Repository interface {
 	GetRefreshSettings(ctx context.Context) (*RefreshSettings, error)
 	SaveRefreshSettings(ctx context.Context, s *RefreshSettings) error
+	GetSetting(ctx context.Context, key string) (string, error)
+	SetSetting(ctx context.Context, key, value string) error
 }

--- a/backend/infra/database/settings_repo.go
+++ b/backend/infra/database/settings_repo.go
@@ -76,6 +76,20 @@ func (r *SettingsRepo) SaveRefreshSettings(ctx context.Context, s *settings.Refr
 	return tx.Commit()
 }
 
+func (r *SettingsRepo) GetSetting(ctx context.Context, key string) (string, error) {
+	var value string
+	err := r.db.QueryRowContext(ctx, `SELECT value FROM app_settings WHERE key = ?`, key).Scan(&value)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return value, err
+}
+
+func (r *SettingsRepo) SetSetting(ctx context.Context, key, value string) error {
+	_, err := r.db.ExecContext(ctx, settingsUpsert, key, value)
+	return err
+}
+
 func applySettingsKey(s *settings.RefreshSettings, key, value string) error {
 	switch key {
 	case "auto_refresh_enabled":

--- a/backend/infra/github/release.go
+++ b/backend/infra/github/release.go
@@ -1,0 +1,94 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAPIURL   = "https://api.github.com"
+	defaultRepo     = "lugassawan/panen"
+	maxResponseSize = 1 << 20 // 1 MB
+)
+
+// Release holds the relevant fields from a GitHub release response.
+type Release struct {
+	TagName string `json:"tag_name"`
+	HTMLURL string `json:"html_url"`
+	Name    string `json:"name"`
+}
+
+// Version returns the tag name without the leading "v" prefix.
+func (r *Release) Version() string {
+	return strings.TrimPrefix(r.TagName, "v")
+}
+
+// Client fetches release information from the GitHub API.
+type Client struct {
+	http   *http.Client
+	apiURL string
+	repo   string
+}
+
+// Option configures the Client.
+type Option func(*Client)
+
+// WithHTTPClient overrides the default HTTP client.
+func WithHTTPClient(c *http.Client) Option {
+	return func(cl *Client) { cl.http = c }
+}
+
+// WithAPIURL overrides the GitHub API base URL (useful for tests).
+func WithAPIURL(url string) Option {
+	return func(cl *Client) { cl.apiURL = url }
+}
+
+// NewClient creates a new GitHub release client.
+func NewClient(opts ...Option) *Client {
+	c := &Client{
+		http:   &http.Client{Timeout: 10 * time.Second},
+		apiURL: defaultAPIURL,
+		repo:   defaultRepo,
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// LatestRelease fetches the latest release from the configured repository.
+func (c *Client) LatestRelease(ctx context.Context) (*Release, error) {
+	url := fmt.Sprintf("%s/repos/%s/releases/latest", c.apiURL, c.repo)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := c.http.Do(req) //nolint:gosec // URL is constructed from controlled apiURL constant
+	if err != nil {
+		return nil, fmt.Errorf("fetch latest release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github API returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	var rel Release
+	if err := json.Unmarshal(body, &rel); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return &rel, nil
+}

--- a/backend/infra/github/release_test.go
+++ b/backend/infra/github/release_test.go
@@ -1,0 +1,91 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestLatestRelease(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantVer    string
+		wantURL    string
+		wantErrStr string
+	}{
+		{
+			name:   "success",
+			status: http.StatusOK,
+			body: `{"tag_name":"v0.2.0",` +
+				`"html_url":"https://github.com/lugassawan/panen/releases/tag/v0.2.0",` +
+				`"name":"v0.2.0"}`,
+			wantVer: "0.2.0",
+			wantURL: "https://github.com/lugassawan/panen/releases/tag/v0.2.0",
+		},
+		{
+			name:       "non-200 status",
+			status:     http.StatusNotFound,
+			body:       `{"message":"Not Found"}`,
+			wantErrStr: "github API returned status 404",
+		},
+		{
+			name:       "malformed JSON",
+			status:     http.StatusOK,
+			body:       `{invalid`,
+			wantErrStr: "decode response",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			client := NewClient(WithAPIURL(srv.URL))
+			rel, err := client.LatestRelease(context.Background())
+
+			if tc.wantErrStr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErrStr)
+				}
+				if got := err.Error(); !strings.Contains(got, tc.wantErrStr) {
+					t.Fatalf("error %q does not contain %q", got, tc.wantErrStr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := rel.Version(); got != tc.wantVer {
+				t.Errorf("Version() = %q, want %q", got, tc.wantVer)
+			}
+			if got := rel.HTMLURL; got != tc.wantURL {
+				t.Errorf("HTMLURL = %q, want %q", got, tc.wantURL)
+			}
+		})
+	}
+}
+
+func TestReleaseVersion(t *testing.T) {
+	tests := []struct {
+		tag  string
+		want string
+	}{
+		{"v1.2.3", "1.2.3"},
+		{"0.1.0", "0.1.0"},
+		{"v0.0.1", "0.0.1"},
+	}
+	for _, tc := range tests {
+		r := &Release{TagName: tc.tag}
+		if got := r.Version(); got != tc.want {
+			t.Errorf("Release{TagName: %q}.Version() = %q, want %q", tc.tag, got, tc.want)
+		}
+	}
+}

--- a/backend/presenter/dto.go
+++ b/backend/presenter/dto.go
@@ -155,6 +155,14 @@ type SuggestionResponse struct {
 	CapitalGainPct  float64 `json:"capitalGainPct"`
 }
 
+// UpdateCheckResponse is the frontend-facing response for an update check.
+type UpdateCheckResponse struct {
+	Available      bool   `json:"available"`
+	CurrentVersion string `json:"currentVersion"`
+	LatestVersion  string `json:"latestVersion"`
+	ReleaseURL     string `json:"releaseURL"`
+}
+
 // ChecklistEvaluationResponse is the frontend-facing response for a checklist evaluation.
 type ChecklistEvaluationResponse struct {
 	Action     string                `json:"action"`

--- a/backend/presenter/update.go
+++ b/backend/presenter/update.go
@@ -1,0 +1,110 @@
+package presenter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/lugassawan/panen/backend/domain/settings"
+	"github.com/lugassawan/panen/backend/usecase"
+	"github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+const (
+	settingSkippedVersion   = "skipped_version"
+	allowedReleaseURLPrefix = "https://github.com/lugassawan/panen/releases/"
+)
+
+// UpdateHandler handles update-related requests from the frontend.
+type UpdateHandler struct {
+	ctx      context.Context
+	update   *usecase.UpdateService
+	settings settings.Repository
+}
+
+// NewUpdateHandler creates a new UpdateHandler.
+func NewUpdateHandler(
+	ctx context.Context,
+	update *usecase.UpdateService,
+	settings settings.Repository,
+) *UpdateHandler {
+	return &UpdateHandler{ctx: ctx, update: update, settings: settings}
+}
+
+// CheckForUpdate checks for updates and returns the result for the frontend.
+func (h *UpdateHandler) CheckForUpdate() (*UpdateCheckResponse, error) {
+	result, err := h.update.Check(h.ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &UpdateCheckResponse{
+		Available:      result.Available,
+		CurrentVersion: result.CurrentVer,
+		LatestVersion:  result.LatestVer,
+		ReleaseURL:     result.ReleaseURL,
+	}, nil
+}
+
+// GetAppVersion returns the current application version.
+func (h *UpdateHandler) GetAppVersion() string {
+	return h.update.CurrentVersion()
+}
+
+// OpenReleaseURL opens the given URL in the user's default browser.
+// Only URLs under the project's GitHub releases path are allowed.
+func (h *UpdateHandler) OpenReleaseURL(url string) {
+	if !strings.HasPrefix(url, allowedReleaseURLPrefix) {
+		runtime.LogWarningf(h.ctx, "blocked non-release URL: %s", url)
+		return
+	}
+	runtime.BrowserOpenURL(h.ctx, url)
+}
+
+// CheckForUpdateOnStartup checks for updates on app startup and shows a native dialog if available.
+// Skipped in dev builds to avoid noisy dialogs during development.
+func (h *UpdateHandler) CheckForUpdateOnStartup() {
+	if h.update.CurrentVersion() == "dev" {
+		return
+	}
+
+	result, err := h.update.Check(h.ctx)
+	if err != nil {
+		runtime.LogWarningf(h.ctx, "startup update check: %v", err)
+		return
+	}
+	if !result.Available {
+		return
+	}
+
+	skipped, _ := h.settings.GetSetting(h.ctx, settingSkippedVersion)
+	if skipped == result.LatestVer {
+		return
+	}
+
+	msg := fmt.Sprintf(
+		"A new version of Panen is available.\n\nCurrent: %s\nLatest: %s",
+		result.CurrentVer, result.LatestVer,
+	)
+
+	selection, err := runtime.MessageDialog(h.ctx, runtime.MessageDialogOptions{
+		Type:          runtime.InfoDialog,
+		Title:         "Update Available",
+		Message:       msg,
+		Buttons:       []string{"View Release", "Skip This Version", "Dismiss"},
+		DefaultButton: "View Release",
+		CancelButton:  "Dismiss",
+	})
+	if err != nil {
+		runtime.LogWarningf(h.ctx, "update dialog: %v", err)
+		return
+	}
+
+	switch selection {
+	case "View Release":
+		runtime.BrowserOpenURL(h.ctx, result.ReleaseURL)
+	case "Skip This Version":
+		if err := h.settings.SetSetting(h.ctx, settingSkippedVersion, result.LatestVer); err != nil {
+			runtime.LogWarningf(h.ctx, "save skipped version: %v", err)
+		}
+	}
+}

--- a/backend/usecase/mock_test.go
+++ b/backend/usecase/mock_test.go
@@ -353,11 +353,13 @@ func (r *mockBuyTxnRepo) Delete(_ context.Context, id string) error {
 type mockSettingsRepo struct {
 	mu       sync.Mutex
 	settings *settings.RefreshSettings
+	kv       map[string]string
 }
 
 func newMockSettingsRepo() *mockSettingsRepo {
 	return &mockSettingsRepo{
 		settings: settings.DefaultRefreshSettings(),
+		kv:       make(map[string]string),
 	}
 }
 
@@ -373,6 +375,19 @@ func (r *mockSettingsRepo) SaveRefreshSettings(_ context.Context, s *settings.Re
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.settings = s
+	return nil
+}
+
+func (r *mockSettingsRepo) GetSetting(_ context.Context, key string) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.kv[key], nil
+}
+
+func (r *mockSettingsRepo) SetSetting(_ context.Context, key, value string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.kv[key] = value
 	return nil
 }
 

--- a/backend/usecase/update.go
+++ b/backend/usecase/update.go
@@ -1,0 +1,99 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ReleaseInfo holds version information about a release.
+type ReleaseInfo struct {
+	Version    string
+	ReleaseURL string
+}
+
+// ReleaseChecker fetches the latest release information.
+type ReleaseChecker interface {
+	LatestRelease(ctx context.Context) (*ReleaseInfo, error)
+}
+
+// UpdateResult holds the result of an update check.
+type UpdateResult struct {
+	Available  bool
+	CurrentVer string
+	LatestVer  string
+	ReleaseURL string
+}
+
+// UpdateService checks for application updates.
+type UpdateService struct {
+	checker    ReleaseChecker
+	currentVer string
+}
+
+// NewUpdateService creates a new UpdateService.
+func NewUpdateService(checker ReleaseChecker, currentVer string) *UpdateService {
+	return &UpdateService{checker: checker, currentVer: currentVer}
+}
+
+// Check fetches the latest release and compares it with the current version.
+func (s *UpdateService) Check(ctx context.Context) (*UpdateResult, error) {
+	info, err := s.checker.LatestRelease(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("check for updates: %w", err)
+	}
+
+	available := compareVersions(s.currentVer, info.Version) < 0
+	return &UpdateResult{
+		Available:  available,
+		CurrentVer: s.currentVer,
+		LatestVer:  info.Version,
+		ReleaseURL: info.ReleaseURL,
+	}, nil
+}
+
+// CurrentVersion returns the embedded application version.
+func (s *UpdateService) CurrentVersion() string {
+	return s.currentVer
+}
+
+// compareVersions compares two semver strings.
+// Returns -1 if a < b, 0 if a == b, 1 if a > b.
+// "dev" is always considered older than any real version.
+func compareVersions(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if a == "dev" {
+		return -1
+	}
+	if b == "dev" {
+		return 1
+	}
+
+	aParts := parseSemver(a)
+	bParts := parseSemver(b)
+
+	for i := range 3 {
+		if aParts[i] < bParts[i] {
+			return -1
+		}
+		if aParts[i] > bParts[i] {
+			return 1
+		}
+	}
+	return 0
+}
+
+// parseSemver extracts [major, minor, patch] from a version string.
+func parseSemver(v string) [3]int {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.SplitN(v, ".", 3)
+	var result [3]int
+	for i := range min(len(parts), 3) {
+		n, _ := strconv.Atoi(parts[i])
+		result[i] = n
+	}
+	return result
+}

--- a/backend/usecase/update_test.go
+++ b/backend/usecase/update_test.go
@@ -1,0 +1,121 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0", "1.0.0", 0},
+		{"0.1.0", "0.2.0", -1},
+		{"0.2.0", "0.1.0", 1},
+		{"1.0.0", "0.9.9", 1},
+		{"0.9.9", "1.0.0", -1},
+		{"1.2.3", "1.2.4", -1},
+		{"1.2.4", "1.2.3", 1},
+		{"dev", "0.1.0", -1},
+		{"0.1.0", "dev", 1},
+		{"dev", "dev", 0},
+		{"0.0.1", "0.0.1", 0},
+		{"1.0.0", "1.0.1", -1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.a+"_vs_"+tc.b, func(t *testing.T) {
+			got := compareVersions(tc.a, tc.b)
+			if got != tc.want {
+				t.Errorf("compareVersions(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+type mockReleaseChecker struct {
+	info *ReleaseInfo
+	err  error
+}
+
+func (m *mockReleaseChecker) LatestRelease(_ context.Context) (*ReleaseInfo, error) {
+	return m.info, m.err
+}
+
+func TestUpdateServiceCheck(t *testing.T) {
+	tests := []struct {
+		name      string
+		current   string
+		latest    *ReleaseInfo
+		checkErr  error
+		wantAvail bool
+		wantErr   bool
+	}{
+		{
+			name:    "update available",
+			current: "0.1.0",
+			latest: &ReleaseInfo{
+				Version:    "0.2.0",
+				ReleaseURL: "https://github.com/lugassawan/panen/releases/tag/v0.2.0",
+			},
+			wantAvail: true,
+		},
+		{
+			name:    "up to date",
+			current: "0.2.0",
+			latest: &ReleaseInfo{
+				Version:    "0.2.0",
+				ReleaseURL: "https://github.com/lugassawan/panen/releases/tag/v0.2.0",
+			},
+			wantAvail: false,
+		},
+		{
+			name:    "dev version always outdated",
+			current: "dev",
+			latest: &ReleaseInfo{
+				Version:    "0.1.0",
+				ReleaseURL: "https://github.com/lugassawan/panen/releases/tag/v0.1.0",
+			},
+			wantAvail: true,
+		},
+		{
+			name:     "checker error",
+			current:  "0.1.0",
+			checkErr: errors.New("network error"),
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			checker := &mockReleaseChecker{info: tc.latest, err: tc.checkErr}
+			svc := NewUpdateService(checker, tc.current)
+
+			result, err := svc.Check(context.Background())
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Available != tc.wantAvail {
+				t.Errorf("Available = %v, want %v", result.Available, tc.wantAvail)
+			}
+			if result.CurrentVer != tc.current {
+				t.Errorf("CurrentVer = %q, want %q", result.CurrentVer, tc.current)
+			}
+		})
+	}
+}
+
+func TestUpdateServiceCurrentVersion(t *testing.T) {
+	svc := NewUpdateService(nil, "1.2.3")
+	if got := svc.CurrentVersion(); got != "1.2.3" {
+		t.Errorf("CurrentVersion() = %q, want %q", got, "1.2.3")
+	}
+}

--- a/backend/version.go
+++ b/backend/version.go
@@ -1,0 +1,9 @@
+package backend
+
+// version is set at build time via -ldflags "-X github.com/lugassawan/panen/backend.version=X.Y.Z".
+var version = "dev"
+
+// Version returns the application version string.
+func Version() string {
+	return version
+}

--- a/frontend/src/pages/settings/SettingsPage.svelte
+++ b/frontend/src/pages/settings/SettingsPage.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
 import { onMount } from "svelte";
 import {
+  CheckForUpdate,
+  GetAppVersion,
   GetRefreshSettings,
+  OpenReleaseURL,
   TriggerRefresh,
   UpdateRefreshSettings,
 } from "../../../wailsjs/go/backend/App";
 import Alert from "../../lib/components/Alert.svelte";
+import Button from "../../lib/components/Button.svelte";
 import Select from "../../lib/components/Select.svelte";
 import ThemeToggle from "../../lib/components/ThemeToggle.svelte";
 import { sync } from "../../lib/stores/sync.svelte";
@@ -17,6 +21,15 @@ let lastRefreshedAt = $state("");
 let loadError = $state<string | null>(null);
 let saveError = $state<string | null>(null);
 
+let appVersion = $state("");
+let updateChecking = $state(false);
+let updateResult = $state<{
+  available: boolean;
+  latestVersion: string;
+  releaseURL: string;
+} | null>(null);
+let updateError = $state<string | null>(null);
+
 onMount(async () => {
   try {
     const settings = await GetRefreshSettings();
@@ -25,6 +38,12 @@ onMount(async () => {
     lastRefreshedAt = settings.lastRefreshedAt;
   } catch (e: unknown) {
     loadError = e instanceof Error ? e.message : String(e);
+  }
+
+  try {
+    appVersion = await GetAppVersion();
+  } catch {
+    appVersion = "unknown";
   }
 });
 
@@ -43,6 +62,24 @@ async function triggerRefresh() {
   } catch {
     // error shown via sync store
   }
+}
+
+async function checkForUpdates() {
+  updateChecking = true;
+  updateResult = null;
+  updateError = null;
+  try {
+    const result = await CheckForUpdate();
+    updateResult = result;
+  } catch (e: unknown) {
+    updateError = e instanceof Error ? e.message : String(e);
+  } finally {
+    updateChecking = false;
+  }
+}
+
+function openRelease(url: string) {
+  OpenReleaseURL(url);
 }
 </script>
 
@@ -121,6 +158,47 @@ async function triggerRefresh() {
         >
           {sync.isSyncing ? "Syncing..." : "Refresh Now"}
         </button>
+      </div>
+    </div>
+
+    <div>
+      <p class="mb-3 text-sm text-text-secondary">About</p>
+      <div class="space-y-4 rounded-lg border border-border-default bg-bg-elevated p-4">
+        <div class="flex items-center justify-between">
+          <span class="text-sm text-text-primary">Version</span>
+          <span class="font-mono text-sm text-text-secondary">{appVersion}</span>
+        </div>
+
+        <Button
+          variant="secondary"
+          size="sm"
+          loading={updateChecking}
+          onclick={checkForUpdates}
+        >
+          Check for Updates
+        </Button>
+
+        {#if updateResult}
+          {#if updateResult.available}
+            <Alert variant="info">
+              Panen {updateResult.latestVersion} is available.
+              <button
+                class="ml-1 font-medium underline underline-offset-2 hover:opacity-80"
+                onclick={() => openRelease(updateResult!.releaseURL)}
+              >
+                View Release
+              </button>
+            </Alert>
+          {:else}
+            <Alert variant="positive">You're up to date.</Alert>
+          {/if}
+        {/if}
+
+        {#if updateError}
+          <Alert variant="negative" dismissible>
+            Failed to check for updates: {updateError}
+          </Alert>
+        {/if}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Issue
Closes #25

## Summary
- Add version checking against GitHub Releases API with manual "Check for Updates" button in Settings and native OS dialog on startup
- Build-time version embedding via `-ldflags -X` (falls back to `"dev"` locally)
- "Skip This Version" persistence via settings key-value store
- Phase 1: redirects to GitHub release page (self-update deferred)

### Architecture
Follows existing layered pattern: `infra/github` → `usecase` → `presenter` → frontend

### New files
- `backend/version.go` — build-time version variable
- `backend/infra/github/release.go` + tests — GitHub API client
- `backend/usecase/update.go` + tests — update service with semver comparison
- `backend/presenter/update.go` — Wails-bound handler with startup dialog

### Modified files
- `backend/domain/settings/repository.go` — added `GetSetting`/`SetSetting` to interface
- `backend/infra/database/settings_repo.go` — implemented generic key-value access
- `backend/app.go` — wired `UpdateHandler` with adapter
- `Makefile` — build targets pass `-ldflags` with version from `wails.json`
- `.github/workflows/release.yml` — build step embeds version from git tag
- `frontend/src/pages/settings/SettingsPage.svelte` — About section with version + update check

## Test Plan
- [x] Linter passes (`make lint`)
- [x] Go tests pass (`make test-go`) — version comparison, GitHub client, update service
- [x] Manual: `make dev` → Settings shows version as "dev"
- [x] Manual: "Check for Updates" button works, shows error alert (404 expected — no releases exist yet)
- [x] Manual: Error alert is dismissible and clears on re-check
- [x] Manual: About section renders correctly in both dark and light themes
- [x] Manual: Startup dialog skipped in dev mode (no nag during development)
- [ ] Manual: `make build` → verify version is embedded (not "dev")
- [ ] Manual: "View Release" opens GitHub release page (requires a published release)

## Notes
- `OpenReleaseURL` validates URLs are under `github.com/lugassawan/panen/releases/` to prevent arbitrary URL opening
- HTTP client has 10s timeout to prevent goroutine leaks on startup check
- Startup check skips when version is `"dev"` to avoid developer nag
- Wails `MessageDialog` may not support 3 custom buttons on all platforms — if so, fall back to 2 buttons
- The 404 error on "Check for Updates" is expected until the first GitHub release is published