### PR TITLE
feat: crash playbook

### DIFF
--- a/backend/app.go
+++ b/backend/app.go
@@ -29,6 +29,7 @@ type App struct {
 	*presenter.ChecklistHandler
 	*presenter.UpdateHandler
 	*presenter.PaydayHandler
+	*presenter.CrashPlaybookHandler
 	db      *database.DB
 	refresh *usecase.RefreshService
 }
@@ -114,6 +115,18 @@ func (a *App) Startup(ctx context.Context) {
 	cashFlowRepo := database.NewCashFlowRepo(conn)
 	paydaySvc := usecase.NewPaydayService(paydayRepo, cashFlowRepo, portfolioRepo, settingsRepo)
 	a.PaydayHandler = presenter.NewPaydayHandler(ctx, paydaySvc)
+
+	crashCapitalRepo := database.NewCrashCapitalRepo(conn)
+	crashPlaybookSvc := usecase.NewCrashPlaybookService(
+		stockRepo,
+		yahoo,
+		portfolioRepo,
+		holdingRepo,
+		crashCapitalRepo,
+		settingsRepo,
+		refreshSvc,
+	)
+	a.CrashPlaybookHandler = presenter.NewCrashPlaybookHandler(ctx, crashPlaybookSvc, portfolioRepo)
 
 	ghClient := github.NewClient()
 	updateChecker := &releaseCheckerAdapter{client: ghClient}

--- a/backend/domain/crashplaybook/diagnostic.go
+++ b/backend/domain/crashplaybook/diagnostic.go
@@ -1,0 +1,33 @@
+package crashplaybook
+
+// EvaluateDiagnostic runs the 4-check falling knife diagnostic.
+//   - marketCrashed: broad market is in crash/correction (auto-detected)
+//   - companyBadNews: company-specific bad news (manual, nil = unknown)
+//   - fundamentalsOK: fundamentals still healthy (manual, nil = unknown)
+//   - belowEntry: price is below valuation entry target (auto-detected)
+//
+// Returns OPPORTUNITY if it's a broad-market-driven dip with healthy fundamentals,
+// FALLING_KNIFE if company-specific issues exist, INCONCLUSIVE otherwise.
+func EvaluateDiagnostic(marketCrashed bool, companyBadNews, fundamentalsOK *bool, belowEntry bool) DiagnosticSignal {
+	if companyBadNews != nil && *companyBadNews {
+		return SignalFallingKnife
+	}
+
+	if fundamentalsOK != nil && !*fundamentalsOK {
+		return SignalFallingKnife
+	}
+
+	if companyBadNews == nil || fundamentalsOK == nil {
+		return SignalInconclusive
+	}
+
+	if marketCrashed && belowEntry {
+		return SignalOpportunity
+	}
+
+	if belowEntry && !marketCrashed {
+		return SignalInconclusive
+	}
+
+	return SignalInconclusive
+}

--- a/backend/domain/crashplaybook/diagnostic_test.go
+++ b/backend/domain/crashplaybook/diagnostic_test.go
@@ -1,0 +1,98 @@
+package crashplaybook
+
+import "testing"
+
+func TestEvaluateDiagnostic(t *testing.T) {
+	boolPtr := func(v bool) *bool { return &v }
+
+	tests := []struct {
+		name           string
+		marketCrashed  bool
+		companyBadNews *bool
+		fundamentalsOK *bool
+		belowEntry     bool
+		want           DiagnosticSignal
+	}{
+		{
+			name:           "opportunity - market crash, no bad news, good fundamentals, below entry",
+			marketCrashed:  true,
+			companyBadNews: boolPtr(false),
+			fundamentalsOK: boolPtr(true),
+			belowEntry:     true,
+			want:           SignalOpportunity,
+		},
+		{
+			name:           "falling knife - company bad news",
+			marketCrashed:  true,
+			companyBadNews: boolPtr(true),
+			fundamentalsOK: boolPtr(true),
+			belowEntry:     true,
+			want:           SignalFallingKnife,
+		},
+		{
+			name:           "falling knife - bad fundamentals",
+			marketCrashed:  true,
+			companyBadNews: boolPtr(false),
+			fundamentalsOK: boolPtr(false),
+			belowEntry:     true,
+			want:           SignalFallingKnife,
+		},
+		{
+			name:           "inconclusive - unknown company news",
+			marketCrashed:  true,
+			companyBadNews: nil,
+			fundamentalsOK: boolPtr(true),
+			belowEntry:     true,
+			want:           SignalInconclusive,
+		},
+		{
+			name:           "inconclusive - unknown fundamentals",
+			marketCrashed:  true,
+			companyBadNews: boolPtr(false),
+			fundamentalsOK: nil,
+			belowEntry:     true,
+			want:           SignalInconclusive,
+		},
+		{
+			name:           "inconclusive - both unknown",
+			marketCrashed:  true,
+			companyBadNews: nil,
+			fundamentalsOK: nil,
+			belowEntry:     true,
+			want:           SignalInconclusive,
+		},
+		{
+			name:           "inconclusive - no market crash, below entry",
+			marketCrashed:  false,
+			companyBadNews: boolPtr(false),
+			fundamentalsOK: boolPtr(true),
+			belowEntry:     true,
+			want:           SignalInconclusive,
+		},
+		{
+			name:           "inconclusive - market crash but above entry",
+			marketCrashed:  true,
+			companyBadNews: boolPtr(false),
+			fundamentalsOK: boolPtr(true),
+			belowEntry:     false,
+			want:           SignalInconclusive,
+		},
+		{
+			name:           "falling knife takes priority over opportunity",
+			marketCrashed:  true,
+			companyBadNews: boolPtr(true),
+			fundamentalsOK: boolPtr(false),
+			belowEntry:     true,
+			want:           SignalFallingKnife,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EvaluateDiagnostic(tt.marketCrashed, tt.companyBadNews, tt.fundamentalsOK, tt.belowEntry)
+			if got != tt.want {
+				t.Errorf("EvaluateDiagnostic() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/domain/crashplaybook/entity.go
+++ b/backend/domain/crashplaybook/entity.go
@@ -1,0 +1,47 @@
+package crashplaybook
+
+import "time"
+
+// MarketStatus holds the current broad market state derived from IHSG (^JKSE).
+type MarketStatus struct {
+	Condition   MarketCondition
+	IHSGPrice   float64
+	IHSGPeak    float64
+	DrawdownPct float64
+	FetchedAt   time.Time
+}
+
+// ResponseLevel defines a single pre-calculated crash response tier.
+type ResponseLevel struct {
+	Level        CrashLevel
+	TriggerPrice float64
+	DeployPct    float64
+}
+
+// StockPlaybook holds the crash playbook for a single holding.
+type StockPlaybook struct {
+	Ticker       string
+	CurrentPrice float64
+	EntryPrice   float64
+	Levels       []ResponseLevel
+	ActiveLevel  *CrashLevel
+}
+
+// CrashCapital represents pre-committed capital reserved for crash deployments.
+type CrashCapital struct {
+	ID          string
+	PortfolioID string
+	Amount      float64
+	Deployed    float64
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// FallingKnifeDiagnostic holds the 4-check evaluation for a stock.
+type FallingKnifeDiagnostic struct {
+	MarketCrashed  bool
+	CompanyBadNews *bool
+	FundamentalsOK *bool
+	BelowEntry     bool
+	Signal         DiagnosticSignal
+}

--- a/backend/domain/crashplaybook/enum.go
+++ b/backend/domain/crashplaybook/enum.go
@@ -1,0 +1,64 @@
+package crashplaybook
+
+import "fmt"
+
+// MarketCondition represents the current state of the broad market.
+type MarketCondition string
+
+const (
+	MarketNormal     MarketCondition = "NORMAL"
+	MarketElevated   MarketCondition = "ELEVATED"
+	MarketCorrection MarketCondition = "CORRECTION"
+	MarketCrash      MarketCondition = "CRASH"
+	MarketRecovery   MarketCondition = "RECOVERY"
+)
+
+// CrashLevel represents a pre-calculated crash response tier.
+type CrashLevel string
+
+const (
+	LevelNormalDip CrashLevel = "NORMAL_DIP"
+	LevelCrash     CrashLevel = "CRASH"
+	LevelExtreme   CrashLevel = "EXTREME"
+)
+
+// DiagnosticSignal is the result of a falling knife diagnostic evaluation.
+type DiagnosticSignal string
+
+const (
+	SignalOpportunity  DiagnosticSignal = "OPPORTUNITY"
+	SignalFallingKnife DiagnosticSignal = "FALLING_KNIFE"
+	SignalInconclusive DiagnosticSignal = "INCONCLUSIVE"
+)
+
+// ParseMarketCondition converts a string to a MarketCondition enum value.
+func ParseMarketCondition(s string) (MarketCondition, error) {
+	switch s {
+	case "NORMAL":
+		return MarketNormal, nil
+	case "ELEVATED":
+		return MarketElevated, nil
+	case "CORRECTION":
+		return MarketCorrection, nil
+	case "CRASH":
+		return MarketCrash, nil
+	case "RECOVERY":
+		return MarketRecovery, nil
+	default:
+		return "", fmt.Errorf("unknown market condition: %s", s)
+	}
+}
+
+// ParseCrashLevel converts a string to a CrashLevel enum value.
+func ParseCrashLevel(s string) (CrashLevel, error) {
+	switch s {
+	case "NORMAL_DIP":
+		return LevelNormalDip, nil
+	case "CRASH":
+		return LevelCrash, nil
+	case "EXTREME":
+		return LevelExtreme, nil
+	default:
+		return "", fmt.Errorf("unknown crash level: %s", s)
+	}
+}

--- a/backend/domain/crashplaybook/market.go
+++ b/backend/domain/crashplaybook/market.go
@@ -1,0 +1,47 @@
+package crashplaybook
+
+// Drawdown thresholds for market condition detection.
+const (
+	thresholdElevated   = -5.0
+	thresholdCorrection = -10.0
+	thresholdCrash      = -20.0
+	thresholdRecovery   = -10.0
+)
+
+// DetectMarketCondition determines the market condition from IHSG price and peak.
+// previousCondition is used to detect recovery (must have been in Crash or Correction).
+func DetectMarketCondition(price, peak float64, previousCondition MarketCondition) MarketCondition {
+	if peak <= 0 {
+		return MarketNormal
+	}
+
+	drawdown := ((price - peak) / peak) * 100
+
+	if isRecovering(drawdown, previousCondition) {
+		return MarketRecovery
+	}
+
+	if drawdown <= thresholdCrash {
+		return MarketCrash
+	}
+	if drawdown <= thresholdCorrection {
+		return MarketCorrection
+	}
+	if drawdown <= thresholdElevated {
+		return MarketElevated
+	}
+	return MarketNormal
+}
+
+// DrawdownPct calculates the percentage drawdown from peak.
+func DrawdownPct(price, peak float64) float64 {
+	if peak <= 0 {
+		return 0
+	}
+	return ((price - peak) / peak) * 100
+}
+
+func isRecovering(drawdown float64, prev MarketCondition) bool {
+	wasCrashOrCorrection := prev == MarketCrash || prev == MarketCorrection || prev == MarketRecovery
+	return wasCrashOrCorrection && drawdown > thresholdRecovery && drawdown <= thresholdElevated
+}

--- a/backend/domain/crashplaybook/market_test.go
+++ b/backend/domain/crashplaybook/market_test.go
@@ -1,0 +1,76 @@
+package crashplaybook
+
+import "testing"
+
+func TestDetectMarketCondition(t *testing.T) {
+	tests := []struct {
+		name     string
+		price    float64
+		peak     float64
+		previous MarketCondition
+		want     MarketCondition
+	}{
+		{name: "normal - no drawdown", price: 7500, peak: 7500, previous: MarketNormal, want: MarketNormal},
+		{name: "normal - small dip", price: 7200, peak: 7500, previous: MarketNormal, want: MarketNormal},
+		{name: "elevated - 5% drawdown", price: 7125, peak: 7500, previous: MarketNormal, want: MarketElevated},
+		{name: "elevated - 8% drawdown", price: 6900, peak: 7500, previous: MarketNormal, want: MarketElevated},
+		{name: "correction - 10% drawdown", price: 6750, peak: 7500, previous: MarketNormal, want: MarketCorrection},
+		{name: "correction - 15% drawdown", price: 6375, peak: 7500, previous: MarketNormal, want: MarketCorrection},
+		{name: "crash - 20% drawdown", price: 6000, peak: 7500, previous: MarketNormal, want: MarketCrash},
+		{name: "crash - 30% drawdown", price: 5250, peak: 7500, previous: MarketNormal, want: MarketCrash},
+		{name: "recovery from crash", price: 7000, peak: 7500, previous: MarketCrash, want: MarketRecovery},
+		{name: "recovery from correction", price: 6900, peak: 7500, previous: MarketCorrection, want: MarketRecovery},
+		{
+			name:     "no recovery from normal - stays elevated",
+			price:    7000,
+			peak:     7500,
+			previous: MarketNormal,
+			want:     MarketElevated,
+		},
+		{
+			name: "recovery to normal when past -5%", price: 7200, peak: 7500,
+			previous: MarketRecovery, want: MarketNormal,
+		},
+		{
+			name: "stays recovery between -5% and -10%", price: 7000, peak: 7500,
+			previous: MarketRecovery, want: MarketRecovery,
+		},
+		{name: "still crash despite previous crash", price: 5500, peak: 7500, previous: MarketCrash, want: MarketCrash},
+		{name: "zero peak returns normal", price: 100, peak: 0, previous: MarketNormal, want: MarketNormal},
+		{name: "exact threshold -5%", price: 7125, peak: 7500, previous: MarketNormal, want: MarketElevated},
+		{name: "exact threshold -10%", price: 6750, peak: 7500, previous: MarketNormal, want: MarketCorrection},
+		{name: "exact threshold -20%", price: 6000, peak: 7500, previous: MarketNormal, want: MarketCrash},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectMarketCondition(tt.price, tt.peak, tt.previous)
+			if got != tt.want {
+				t.Errorf("DetectMarketCondition(%v, %v, %v) = %v, want %v",
+					tt.price, tt.peak, tt.previous, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDrawdownPct(t *testing.T) {
+	tests := []struct {
+		name  string
+		price float64
+		peak  float64
+		want  float64
+	}{
+		{name: "no drawdown", price: 7500, peak: 7500, want: 0},
+		{name: "10% drawdown", price: 6750, peak: 7500, want: -10},
+		{name: "zero peak", price: 100, peak: 0, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DrawdownPct(tt.price, tt.peak)
+			if got != tt.want {
+				t.Errorf("DrawdownPct(%v, %v) = %v, want %v", tt.price, tt.peak, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/domain/crashplaybook/playbook.go
+++ b/backend/domain/crashplaybook/playbook.go
@@ -1,0 +1,28 @@
+package crashplaybook
+
+// ComputeResponseLevels calculates 3 response tiers based on entry price and 52-week low.
+// deployPcts defines the deployment percentage for each level [normalDip, crash, extreme].
+func ComputeResponseLevels(entryPrice, low52Week float64, deployPcts [3]float64) []ResponseLevel {
+	normalDip := entryPrice
+	crash := (entryPrice + low52Week) / 2
+	extreme := low52Week * 1.05
+
+	return []ResponseLevel{
+		{Level: LevelNormalDip, TriggerPrice: normalDip, DeployPct: deployPcts[0]},
+		{Level: LevelCrash, TriggerPrice: crash, DeployPct: deployPcts[1]},
+		{Level: LevelExtreme, TriggerPrice: extreme, DeployPct: deployPcts[2]},
+	}
+}
+
+// DetermineActiveLevel returns the deepest crash level that has been triggered,
+// or nil if price is above all trigger levels.
+func DetermineActiveLevel(price float64, levels []ResponseLevel) *CrashLevel {
+	var active *CrashLevel
+	for i := range levels {
+		if price <= levels[i].TriggerPrice {
+			lvl := levels[i].Level
+			active = &lvl
+		}
+	}
+	return active
+}

--- a/backend/domain/crashplaybook/playbook_test.go
+++ b/backend/domain/crashplaybook/playbook_test.go
@@ -1,0 +1,77 @@
+package crashplaybook
+
+import "testing"
+
+func TestComputeResponseLevels(t *testing.T) {
+	entryPrice := 1000.0
+	low52Week := 600.0
+	deployPcts := [3]float64{30, 40, 30}
+
+	levels := ComputeResponseLevels(entryPrice, low52Week, deployPcts)
+	if len(levels) != 3 {
+		t.Fatalf("expected 3 levels, got %d", len(levels))
+	}
+
+	tests := []struct {
+		name         string
+		level        CrashLevel
+		triggerPrice float64
+		deployPct    float64
+	}{
+		{name: "normal dip", level: LevelNormalDip, triggerPrice: 1000, deployPct: 30},
+		{name: "crash", level: LevelCrash, triggerPrice: 800, deployPct: 40},
+		{name: "extreme", level: LevelExtreme, triggerPrice: 630, deployPct: 30},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if levels[i].Level != tt.level {
+				t.Errorf("level %d: got level %v, want %v", i, levels[i].Level, tt.level)
+			}
+			if levels[i].TriggerPrice != tt.triggerPrice {
+				t.Errorf("level %d: got trigger %v, want %v", i, levels[i].TriggerPrice, tt.triggerPrice)
+			}
+			if levels[i].DeployPct != tt.deployPct {
+				t.Errorf("level %d: got deploy %v, want %v", i, levels[i].DeployPct, tt.deployPct)
+			}
+		})
+	}
+}
+
+func TestDetermineActiveLevel(t *testing.T) {
+	levels := []ResponseLevel{
+		{Level: LevelNormalDip, TriggerPrice: 1000},
+		{Level: LevelCrash, TriggerPrice: 800},
+		{Level: LevelExtreme, TriggerPrice: 630},
+	}
+
+	normalDip := LevelNormalDip
+	crash := LevelCrash
+	extreme := LevelExtreme
+
+	tests := []struct {
+		name  string
+		price float64
+		want  *CrashLevel
+	}{
+		{name: "above all levels", price: 1100, want: nil},
+		{name: "at normal dip", price: 1000, want: &normalDip},
+		{name: "between normal dip and crash", price: 900, want: &normalDip},
+		{name: "at crash", price: 800, want: &crash},
+		{name: "between crash and extreme", price: 700, want: &crash},
+		{name: "at extreme", price: 630, want: &extreme},
+		{name: "below extreme", price: 500, want: &extreme},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetermineActiveLevel(tt.price, levels)
+			if tt.want == nil && got != nil {
+				t.Errorf("DetermineActiveLevel(%v) = %v, want nil", tt.price, *got)
+			}
+			if tt.want != nil && (got == nil || *got != *tt.want) {
+				t.Errorf("DetermineActiveLevel(%v) = %v, want %v", tt.price, got, *tt.want)
+			}
+		})
+	}
+}

--- a/backend/domain/crashplaybook/repository.go
+++ b/backend/domain/crashplaybook/repository.go
@@ -1,0 +1,9 @@
+package crashplaybook
+
+import "context"
+
+// CrashCapitalRepository defines persistence operations for crash capital.
+type CrashCapitalRepository interface {
+	Upsert(ctx context.Context, cc *CrashCapital) error
+	GetByPortfolioID(ctx context.Context, portfolioID string) (*CrashCapital, error)
+}

--- a/backend/infra/database/crash_capital_repo.go
+++ b/backend/infra/database/crash_capital_repo.go
@@ -1,0 +1,62 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/lugassawan/panen/backend/domain/crashplaybook"
+	"github.com/lugassawan/panen/backend/domain/shared"
+)
+
+const (
+	crashCapitalUpsert = `INSERT INTO crash_capital
+		(id, portfolio_id, amount, deployed, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(portfolio_id) DO UPDATE SET
+		amount = excluded.amount, deployed = excluded.deployed,
+		updated_at = excluded.updated_at`
+	crashCapitalGetByPortfolioID = `SELECT id, portfolio_id, amount, deployed,
+		created_at, updated_at FROM crash_capital WHERE portfolio_id = ?`
+)
+
+// CrashCapitalRepo implements crashplaybook.CrashCapitalRepository.
+type CrashCapitalRepo struct {
+	db *sql.DB
+}
+
+// NewCrashCapitalRepo creates a new CrashCapitalRepo.
+func NewCrashCapitalRepo(db *sql.DB) *CrashCapitalRepo {
+	return &CrashCapitalRepo{db: db}
+}
+
+func (r *CrashCapitalRepo) Upsert(ctx context.Context, cc *crashplaybook.CrashCapital) error {
+	_, err := r.db.ExecContext(ctx, crashCapitalUpsert,
+		cc.ID, cc.PortfolioID, cc.Amount, cc.Deployed,
+		formatTime(cc.CreatedAt), formatTime(cc.UpdatedAt))
+	return err
+}
+
+func (r *CrashCapitalRepo) GetByPortfolioID(
+	ctx context.Context,
+	portfolioID string,
+) (*crashplaybook.CrashCapital, error) {
+	var cc crashplaybook.CrashCapital
+	var createdAt, updatedAt string
+	err := r.db.QueryRowContext(ctx, crashCapitalGetByPortfolioID, portfolioID).Scan(
+		&cc.ID, &cc.PortfolioID, &cc.Amount, &cc.Deployed, &createdAt, &updatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, shared.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	var parseErr error
+	if cc.CreatedAt, parseErr = parseTime(createdAt); parseErr != nil {
+		return nil, parseErr
+	}
+	if cc.UpdatedAt, parseErr = parseTime(updatedAt); parseErr != nil {
+		return nil, parseErr
+	}
+	return &cc, nil
+}

--- a/backend/infra/database/crash_capital_repo_test.go
+++ b/backend/infra/database/crash_capital_repo_test.go
@@ -1,0 +1,157 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lugassawan/panen/backend/domain/brokerage"
+	"github.com/lugassawan/panen/backend/domain/crashplaybook"
+	"github.com/lugassawan/panen/backend/domain/portfolio"
+	"github.com/lugassawan/panen/backend/domain/shared"
+	"github.com/lugassawan/panen/backend/domain/user"
+)
+
+type crashCapitalTestFixture struct {
+	repo      *CrashCapitalRepo
+	portfolio *portfolio.Portfolio
+	ctx       context.Context
+	now       time.Time
+}
+
+func setupCrashCapitalTest(t *testing.T) crashCapitalTestFixture {
+	t.Helper()
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	userRepo := NewUserRepo(db)
+	broRepo := NewBrokerageRepo(db)
+	portRepo := NewPortfolioRepo(db)
+
+	p := &user.Profile{
+		ID: shared.NewID(), Name: "Test User",
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := userRepo.Create(ctx, p); err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+	a := &brokerage.Account{
+		ID: shared.NewID(), ProfileID: p.ID, BrokerName: "Broker",
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := broRepo.Create(ctx, a); err != nil {
+		t.Fatalf("create brokerage: %v", err)
+	}
+	port := &portfolio.Portfolio{
+		ID:                 shared.NewID(),
+		BrokerageAccountID: a.ID,
+		Name:               "Test Portfolio",
+		Mode:               portfolio.ModeValue,
+		RiskProfile:        portfolio.RiskProfileConservative,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	if err := portRepo.Create(ctx, port); err != nil {
+		t.Fatalf("create portfolio: %v", err)
+	}
+
+	return crashCapitalTestFixture{
+		repo:      NewCrashCapitalRepo(db),
+		portfolio: port,
+		ctx:       ctx,
+		now:       now,
+	}
+}
+
+func TestCrashCapitalRepoUpsertAndGet(t *testing.T) {
+	f := setupCrashCapitalTest(t)
+
+	cc := &crashplaybook.CrashCapital{
+		ID:          shared.NewID(),
+		PortfolioID: f.portfolio.ID,
+		Amount:      10_000_000,
+		Deployed:    0,
+		CreatedAt:   f.now,
+		UpdatedAt:   f.now,
+	}
+	if err := f.repo.Upsert(f.ctx, cc); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+
+	got, err := f.repo.GetByPortfolioID(f.ctx, f.portfolio.ID)
+	if err != nil {
+		t.Fatalf("GetByPortfolioID() error = %v", err)
+	}
+	if got.Amount != 10_000_000 {
+		t.Errorf("Amount = %v, want 10000000", got.Amount)
+	}
+	if got.PortfolioID != f.portfolio.ID {
+		t.Errorf("PortfolioID = %q, want %q", got.PortfolioID, f.portfolio.ID)
+	}
+}
+
+func TestCrashCapitalRepoUpsertUpdatesExisting(t *testing.T) {
+	f := setupCrashCapitalTest(t)
+
+	cc := &crashplaybook.CrashCapital{
+		ID:          shared.NewID(),
+		PortfolioID: f.portfolio.ID,
+		Amount:      10_000_000,
+		CreatedAt:   f.now,
+		UpdatedAt:   f.now,
+	}
+	if err := f.repo.Upsert(f.ctx, cc); err != nil {
+		t.Fatalf("Upsert() insert error = %v", err)
+	}
+
+	cc.Amount = 20_000_000
+	cc.UpdatedAt = f.now.Add(time.Hour)
+	if err := f.repo.Upsert(f.ctx, cc); err != nil {
+		t.Fatalf("Upsert() update error = %v", err)
+	}
+
+	got, err := f.repo.GetByPortfolioID(f.ctx, f.portfolio.ID)
+	if err != nil {
+		t.Fatalf("GetByPortfolioID() error = %v", err)
+	}
+	if got.Amount != 20_000_000 {
+		t.Errorf("Amount = %v, want 20000000", got.Amount)
+	}
+}
+
+func TestCrashCapitalRepoGetByPortfolioIDNotFound(t *testing.T) {
+	f := setupCrashCapitalTest(t)
+
+	_, err := f.repo.GetByPortfolioID(f.ctx, "nonexistent")
+	if !errors.Is(err, shared.ErrNotFound) {
+		t.Errorf("GetByPortfolioID() error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestCrashCapitalRepoTimestampRoundTrip(t *testing.T) {
+	f := setupCrashCapitalTest(t)
+
+	cc := &crashplaybook.CrashCapital{
+		ID:          shared.NewID(),
+		PortfolioID: f.portfolio.ID,
+		Amount:      5_000_000,
+		CreatedAt:   f.now,
+		UpdatedAt:   f.now.Add(2 * time.Hour),
+	}
+	if err := f.repo.Upsert(f.ctx, cc); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+
+	got, err := f.repo.GetByPortfolioID(f.ctx, f.portfolio.ID)
+	if err != nil {
+		t.Fatalf("GetByPortfolioID() error = %v", err)
+	}
+	if !got.CreatedAt.Equal(f.now) {
+		t.Errorf("CreatedAt = %v, want %v", got.CreatedAt, f.now)
+	}
+	if !got.UpdatedAt.Equal(f.now.Add(2 * time.Hour)) {
+		t.Errorf("UpdatedAt = %v, want %v", got.UpdatedAt, f.now.Add(2*time.Hour))
+	}
+}

--- a/backend/infra/database/schema.go
+++ b/backend/infra/database/schema.go
@@ -8,6 +8,7 @@ var migrations = []string{
 	migrationV4,
 	migrationV5,
 	migrationV6,
+	migrationV7,
 }
 
 const migrationV1 = `
@@ -154,4 +155,19 @@ CREATE TABLE cash_flows (
 	created_at    TEXT NOT NULL
 );
 INSERT INTO app_settings (key, value) VALUES ('payday_day', '0');
+`
+
+const migrationV7 = `
+CREATE TABLE crash_capital (
+	id           TEXT PRIMARY KEY,
+	portfolio_id TEXT NOT NULL REFERENCES portfolios(id) ON DELETE CASCADE,
+	amount       REAL NOT NULL DEFAULT 0,
+	deployed     REAL NOT NULL DEFAULT 0,
+	created_at   TEXT NOT NULL,
+	updated_at   TEXT NOT NULL,
+	UNIQUE(portfolio_id)
+);
+INSERT INTO app_settings (key, value) VALUES ('crash_deploy_pct_normal', '30');
+INSERT INTO app_settings (key, value) VALUES ('crash_deploy_pct_crash', '40');
+INSERT INTO app_settings (key, value) VALUES ('crash_deploy_pct_extreme', '30');
 `

--- a/backend/infra/scraper/ticker.go
+++ b/backend/infra/scraper/ticker.go
@@ -3,7 +3,11 @@ package scraper
 import "strings"
 
 // FormatIDX appends ".JK" suffix for Jakarta Stock Exchange tickers.
+// Index tickers starting with "^" (e.g. ^JKSE) are returned unchanged.
 func FormatIDX(ticker string) string {
+	if strings.HasPrefix(ticker, "^") {
+		return ticker
+	}
 	if strings.HasSuffix(ticker, ".JK") {
 		return ticker
 	}

--- a/backend/infra/scraper/ticker_test.go
+++ b/backend/infra/scraper/ticker_test.go
@@ -13,6 +13,8 @@ func TestFormatIDX(t *testing.T) {
 		{name: "lowercase ticker", ticker: "bbca", want: "bbca.JK"},
 		{name: "empty string", ticker: "", want: ".JK"},
 		{name: "partial suffix", ticker: "BBCA.J", want: "BBCA.J.JK"},
+		{name: "index ticker ^JKSE", ticker: "^JKSE", want: "^JKSE"},
+		{name: "index ticker ^DJI", ticker: "^DJI", want: "^DJI"},
 	}
 
 	for _, tt := range tests {

--- a/backend/presenter/crashplaybook.go
+++ b/backend/presenter/crashplaybook.go
@@ -1,0 +1,184 @@
+package presenter
+
+import (
+	"context"
+
+	"github.com/lugassawan/panen/backend/domain/crashplaybook"
+	"github.com/lugassawan/panen/backend/domain/portfolio"
+	"github.com/lugassawan/panen/backend/usecase"
+)
+
+// CrashPlaybookHandler handles crash playbook requests from the frontend.
+type CrashPlaybookHandler struct {
+	ctx        context.Context
+	service    *usecase.CrashPlaybookService
+	portfolios portfolio.Repository
+}
+
+// NewCrashPlaybookHandler creates a new CrashPlaybookHandler.
+func NewCrashPlaybookHandler(
+	ctx context.Context,
+	service *usecase.CrashPlaybookService,
+	portfolios portfolio.Repository,
+) *CrashPlaybookHandler {
+	return &CrashPlaybookHandler{ctx: ctx, service: service, portfolios: portfolios}
+}
+
+// ListAllPortfolios returns all portfolios for the portfolio selector.
+func (h *CrashPlaybookHandler) ListAllPortfolios() ([]*PortfolioResponse, error) {
+	all, err := h.portfolios.ListAll(h.ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*PortfolioResponse, len(all))
+	for i, p := range all {
+		result[i] = newPortfolioResponse(p)
+	}
+	return result, nil
+}
+
+// GetMarketStatus returns the current IHSG market condition.
+func (h *CrashPlaybookHandler) GetMarketStatus() (*MarketStatusResponse, error) {
+	status, err := h.service.GetMarketStatus(h.ctx)
+	if err != nil {
+		return nil, err
+	}
+	return newMarketStatusResponse(status), nil
+}
+
+// GetPortfolioPlaybook returns crash playbooks for all holdings in a portfolio.
+func (h *CrashPlaybookHandler) GetPortfolioPlaybook(portfolioID string) (*PortfolioPlaybookResponse, error) {
+	pb, err := h.service.GetPortfolioPlaybook(h.ctx, portfolioID)
+	if err != nil {
+		return nil, err
+	}
+	return newPortfolioPlaybookResponse(pb), nil
+}
+
+// GetDiagnostic evaluates the falling knife diagnostic for a stock.
+func (h *CrashPlaybookHandler) GetDiagnostic(
+	ticker, portfolioID string,
+	companyBadNews, fundamentalsOK *bool,
+) (*DiagnosticResponse, error) {
+	diag, err := h.service.GetDiagnostic(h.ctx, ticker, portfolioID, companyBadNews, fundamentalsOK)
+	if err != nil {
+		return nil, err
+	}
+	return newDiagnosticResponse(diag), nil
+}
+
+// GetCrashCapital returns the crash capital for a portfolio.
+func (h *CrashPlaybookHandler) GetCrashCapital(portfolioID string) (*CrashCapitalResponse, error) {
+	cc, err := h.service.GetCrashCapital(h.ctx, portfolioID)
+	if err != nil {
+		return nil, err
+	}
+	return &CrashCapitalResponse{
+		PortfolioID: cc.PortfolioID,
+		Amount:      cc.Amount,
+		Deployed:    cc.Deployed,
+	}, nil
+}
+
+// SaveCrashCapital persists the crash capital amount for a portfolio.
+func (h *CrashPlaybookHandler) SaveCrashCapital(portfolioID string, amount float64) error {
+	return h.service.SaveCrashCapital(h.ctx, portfolioID, amount)
+}
+
+// GetDeploymentPlan returns the capital allocation breakdown per crash level.
+func (h *CrashPlaybookHandler) GetDeploymentPlan(portfolioID string) (*DeploymentPlanResponse, error) {
+	plan, err := h.service.GetDeploymentPlan(h.ctx, portfolioID)
+	if err != nil {
+		return nil, err
+	}
+	return newDeploymentPlanResponse(plan), nil
+}
+
+// GetDeploymentSettings returns the deployment percentage settings.
+func (h *CrashPlaybookHandler) GetDeploymentSettings() (*DeploymentSettingsResponse, error) {
+	normal, crash, extreme, err := h.service.GetDeploymentSettings(h.ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &DeploymentSettingsResponse{
+		Normal:  normal,
+		Crash:   crash,
+		Extreme: extreme,
+	}, nil
+}
+
+// SaveDeploymentSettings persists deployment percentage settings.
+func (h *CrashPlaybookHandler) SaveDeploymentSettings(normal, crash, extreme float64) error {
+	return h.service.SaveDeploymentSettings(h.ctx, normal, crash, extreme)
+}
+
+func newMarketStatusResponse(s *crashplaybook.MarketStatus) *MarketStatusResponse {
+	return &MarketStatusResponse{
+		Condition:   string(s.Condition),
+		IHSGPrice:   s.IHSGPrice,
+		IHSGPeak:    s.IHSGPeak,
+		DrawdownPct: s.DrawdownPct,
+		FetchedAt:   formatDTO(s.FetchedAt),
+	}
+}
+
+func newPortfolioPlaybookResponse(pb *usecase.PortfolioPlaybook) *PortfolioPlaybookResponse {
+	stocks := make([]StockPlaybookResponse, len(pb.Stocks))
+	for i, sp := range pb.Stocks {
+		stocks[i] = newStockPlaybookResponse(sp)
+	}
+	return &PortfolioPlaybookResponse{
+		Market:     *newMarketStatusResponse(pb.Market),
+		Stocks:     stocks,
+		RefreshMin: pb.RefreshMin,
+	}
+}
+
+func newStockPlaybookResponse(sp crashplaybook.StockPlaybook) StockPlaybookResponse {
+	levels := make([]ResponseLevelResponse, len(sp.Levels))
+	for i, l := range sp.Levels {
+		levels[i] = ResponseLevelResponse{
+			Level:        string(l.Level),
+			TriggerPrice: l.TriggerPrice,
+			DeployPct:    l.DeployPct,
+		}
+	}
+	resp := StockPlaybookResponse{
+		Ticker:       sp.Ticker,
+		CurrentPrice: sp.CurrentPrice,
+		EntryPrice:   sp.EntryPrice,
+		Levels:       levels,
+	}
+	if sp.ActiveLevel != nil {
+		s := string(*sp.ActiveLevel)
+		resp.ActiveLevel = &s
+	}
+	return resp
+}
+
+func newDiagnosticResponse(d *crashplaybook.FallingKnifeDiagnostic) *DiagnosticResponse {
+	return &DiagnosticResponse{
+		MarketCrashed:  d.MarketCrashed,
+		CompanyBadNews: d.CompanyBadNews,
+		FundamentalsOK: d.FundamentalsOK,
+		BelowEntry:     d.BelowEntry,
+		Signal:         string(d.Signal),
+	}
+}
+
+func newDeploymentPlanResponse(plan *usecase.DeploymentPlan) *DeploymentPlanResponse {
+	levels := make([]DeploymentLevelPlanResponse, len(plan.Levels))
+	for i, l := range plan.Levels {
+		levels[i] = DeploymentLevelPlanResponse{
+			Level:  string(l.Level),
+			Pct:    l.Pct,
+			Amount: l.Amount,
+		}
+	}
+	return &DeploymentPlanResponse{
+		Total:     plan.Total,
+		Deployed:  plan.Deployed,
+		Remaining: plan.Remaining,
+		Levels:    levels,
+	}
+}

--- a/backend/presenter/crashplaybook_dto.go
+++ b/backend/presenter/crashplaybook_dto.go
@@ -1,0 +1,71 @@
+package presenter
+
+// MarketStatusResponse is the frontend-facing response for IHSG market status.
+type MarketStatusResponse struct {
+	Condition   string  `json:"condition"`
+	IHSGPrice   float64 `json:"ihsgPrice"`
+	IHSGPeak    float64 `json:"ihsgPeak"`
+	DrawdownPct float64 `json:"drawdownPct"`
+	FetchedAt   string  `json:"fetchedAt"`
+}
+
+// ResponseLevelResponse is the frontend-facing response for a single crash response tier.
+type ResponseLevelResponse struct {
+	Level        string  `json:"level"`
+	TriggerPrice float64 `json:"triggerPrice"`
+	DeployPct    float64 `json:"deployPct"`
+}
+
+// StockPlaybookResponse is the frontend-facing response for a stock's crash playbook.
+type StockPlaybookResponse struct {
+	Ticker       string                  `json:"ticker"`
+	CurrentPrice float64                 `json:"currentPrice"`
+	EntryPrice   float64                 `json:"entryPrice"`
+	Levels       []ResponseLevelResponse `json:"levels"`
+	ActiveLevel  *string                 `json:"activeLevel,omitempty"`
+}
+
+// PortfolioPlaybookResponse is the frontend-facing response for a portfolio crash playbook.
+type PortfolioPlaybookResponse struct {
+	Market     MarketStatusResponse    `json:"market"`
+	Stocks     []StockPlaybookResponse `json:"stocks"`
+	RefreshMin int                     `json:"refreshMin"`
+}
+
+// DiagnosticResponse is the frontend-facing response for falling knife diagnostic.
+type DiagnosticResponse struct {
+	MarketCrashed  bool   `json:"marketCrashed"`
+	CompanyBadNews *bool  `json:"companyBadNews"`
+	FundamentalsOK *bool  `json:"fundamentalsOK"`
+	BelowEntry     bool   `json:"belowEntry"`
+	Signal         string `json:"signal"`
+}
+
+// CrashCapitalResponse is the frontend-facing response for crash capital.
+type CrashCapitalResponse struct {
+	PortfolioID string  `json:"portfolioId"`
+	Amount      float64 `json:"amount"`
+	Deployed    float64 `json:"deployed"`
+}
+
+// DeploymentLevelPlanResponse is the frontend-facing response for a level's deployment plan.
+type DeploymentLevelPlanResponse struct {
+	Level  string  `json:"level"`
+	Pct    float64 `json:"pct"`
+	Amount float64 `json:"amount"`
+}
+
+// DeploymentPlanResponse is the frontend-facing response for the full deployment plan.
+type DeploymentPlanResponse struct {
+	Total     float64                       `json:"total"`
+	Deployed  float64                       `json:"deployed"`
+	Remaining float64                       `json:"remaining"`
+	Levels    []DeploymentLevelPlanResponse `json:"levels"`
+}
+
+// DeploymentSettingsResponse is the frontend-facing response for deployment percentages.
+type DeploymentSettingsResponse struct {
+	Normal  float64 `json:"normal"`
+	Crash   float64 `json:"crash"`
+	Extreme float64 `json:"extreme"`
+}

--- a/backend/usecase/crashplaybook.go
+++ b/backend/usecase/crashplaybook.go
@@ -1,0 +1,383 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"math"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/lugassawan/panen/backend/domain/crashplaybook"
+	"github.com/lugassawan/panen/backend/domain/portfolio"
+	"github.com/lugassawan/panen/backend/domain/settings"
+	"github.com/lugassawan/panen/backend/domain/shared"
+	"github.com/lugassawan/panen/backend/domain/stock"
+	"github.com/lugassawan/panen/backend/domain/valuation"
+)
+
+const (
+	ihsgTicker           = "^JKSE"
+	marketCacheTTL       = 1 * time.Hour
+	settingDeployNormal  = "crash_deploy_pct_normal"
+	settingDeployCrash   = "crash_deploy_pct_crash"
+	settingDeployExtreme = "crash_deploy_pct_extreme"
+)
+
+// ErrInvalidDeploymentSum is returned when deployment percentages don't sum to 100.
+var ErrInvalidDeploymentSum = errors.New("deployment percentages must sum to 100")
+
+// PortfolioPlaybook is the full crash playbook for a portfolio.
+type PortfolioPlaybook struct {
+	Market     *crashplaybook.MarketStatus
+	Stocks     []crashplaybook.StockPlaybook
+	RefreshMin int
+}
+
+// DeploymentPlan shows how crash capital is allocated per level.
+type DeploymentPlan struct {
+	Total     float64
+	Deployed  float64
+	Remaining float64
+	Levels    []DeploymentLevelPlan
+}
+
+// DeploymentLevelPlan shows allocation for a single crash level.
+type DeploymentLevelPlan struct {
+	Level  crashplaybook.CrashLevel
+	Pct    float64
+	Amount float64
+}
+
+// CrashPlaybookService manages crash playbook computations.
+type CrashPlaybookService struct {
+	stockData    stock.Repository
+	provider     stock.DataProvider
+	portfolios   portfolio.Repository
+	holdings     portfolio.HoldingRepository
+	crashCapital crashplaybook.CrashCapitalRepository
+	settings     settings.Repository
+	refresh      *RefreshService
+
+	mu            sync.Mutex
+	marketCache   *crashplaybook.MarketStatus
+	prevCondition crashplaybook.MarketCondition
+}
+
+// NewCrashPlaybookService creates a new CrashPlaybookService.
+func NewCrashPlaybookService(
+	stockData stock.Repository,
+	provider stock.DataProvider,
+	portfolios portfolio.Repository,
+	holdings portfolio.HoldingRepository,
+	crashCapital crashplaybook.CrashCapitalRepository,
+	settings settings.Repository,
+	refresh *RefreshService,
+) *CrashPlaybookService {
+	return &CrashPlaybookService{
+		stockData:    stockData,
+		provider:     provider,
+		portfolios:   portfolios,
+		holdings:     holdings,
+		crashCapital: crashCapital,
+		settings:     settings,
+		refresh:      refresh,
+	}
+}
+
+// GetMarketStatus returns the current IHSG-based market condition.
+func (s *CrashPlaybookService) GetMarketStatus(ctx context.Context) (*crashplaybook.MarketStatus, error) {
+	s.mu.Lock()
+	if s.marketCache != nil && time.Since(s.marketCache.FetchedAt) < marketCacheTTL {
+		cached := *s.marketCache
+		s.mu.Unlock()
+		return &cached, nil
+	}
+	s.mu.Unlock()
+
+	data, err := s.stockData.GetByTickerAndSource(ctx, ihsgTicker, s.provider.Source())
+	if err != nil && !errors.Is(err, shared.ErrNotFound) {
+		return nil, fmt.Errorf("get IHSG data: %w", err)
+	}
+
+	if data == nil || time.Since(data.FetchedAt) >= marketCacheTTL {
+		price, fetchErr := s.provider.FetchPrice(ctx, ihsgTicker)
+		if fetchErr != nil {
+			if data != nil {
+				return s.buildMarketStatus(data), nil
+			}
+			return nil, fmt.Errorf("fetch IHSG: %w", fetchErr)
+		}
+		data = &stock.Data{
+			ID:         shared.NewID(),
+			Ticker:     ihsgTicker,
+			Price:      price.Price,
+			High52Week: price.High52Week,
+			Low52Week:  price.Low52Week,
+			FetchedAt:  time.Now().UTC(),
+			Source:     s.provider.Source(),
+		}
+		if upsertErr := s.stockData.Upsert(ctx, data); upsertErr != nil {
+			log.Printf("warn: failed to persist IHSG data: %v", upsertErr)
+		}
+	}
+
+	return s.buildMarketStatus(data), nil
+}
+
+// GetPortfolioPlaybook returns crash playbooks for all holdings in a portfolio.
+func (s *CrashPlaybookService) GetPortfolioPlaybook(
+	ctx context.Context,
+	portfolioID string,
+) (*PortfolioPlaybook, error) {
+	p, err := s.portfolios.GetByID(ctx, portfolioID)
+	if err != nil {
+		return nil, fmt.Errorf("get portfolio: %w", err)
+	}
+
+	holdingList, err := s.holdings.ListByPortfolioID(ctx, portfolioID)
+	if err != nil {
+		return nil, fmt.Errorf("list holdings: %w", err)
+	}
+
+	market, err := s.GetMarketStatus(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	deployPcts := s.readDeployPcts(ctx)
+
+	var stocks []crashplaybook.StockPlaybook
+	rp := valuation.RiskProfile(p.RiskProfile)
+	for _, h := range holdingList {
+		sp, err := s.buildStockPlaybook(ctx, h, rp, deployPcts)
+		if err != nil {
+			continue
+		}
+		stocks = append(stocks, *sp)
+	}
+
+	return &PortfolioPlaybook{
+		Market:     market,
+		Stocks:     stocks,
+		RefreshMin: SuggestedRefreshInterval(market.Condition),
+	}, nil
+}
+
+// GetDiagnostic evaluates the falling knife diagnostic for a stock.
+func (s *CrashPlaybookService) GetDiagnostic(
+	ctx context.Context,
+	ticker string,
+	portfolioID string,
+	companyBadNews, fundamentalsOK *bool,
+) (*crashplaybook.FallingKnifeDiagnostic, error) {
+	market, err := s.GetMarketStatus(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	marketCrashed := market.Condition == crashplaybook.MarketCrash || market.Condition == crashplaybook.MarketCorrection
+
+	p, err := s.portfolios.GetByID(ctx, portfolioID)
+	if err != nil {
+		return nil, fmt.Errorf("get portfolio: %w", err)
+	}
+
+	belowEntry := false
+	data, err := s.stockData.GetByTickerAndSource(ctx, ticker, s.provider.Source())
+	if err == nil {
+		result, valErr := evaluate(data, valuation.RiskProfile(p.RiskProfile))
+		if valErr == nil {
+			belowEntry = data.Price <= result.EntryPrice
+		}
+	}
+
+	signal := crashplaybook.EvaluateDiagnostic(marketCrashed, companyBadNews, fundamentalsOK, belowEntry)
+
+	return &crashplaybook.FallingKnifeDiagnostic{
+		MarketCrashed:  marketCrashed,
+		CompanyBadNews: companyBadNews,
+		FundamentalsOK: fundamentalsOK,
+		BelowEntry:     belowEntry,
+		Signal:         signal,
+	}, nil
+}
+
+// GetCrashCapital returns the crash capital for a portfolio.
+func (s *CrashPlaybookService) GetCrashCapital(
+	ctx context.Context,
+	portfolioID string,
+) (*crashplaybook.CrashCapital, error) {
+	cc, err := s.crashCapital.GetByPortfolioID(ctx, portfolioID)
+	if errors.Is(err, shared.ErrNotFound) {
+		return &crashplaybook.CrashCapital{PortfolioID: portfolioID}, nil
+	}
+	return cc, err
+}
+
+// SaveCrashCapital persists the crash capital amount for a portfolio.
+func (s *CrashPlaybookService) SaveCrashCapital(ctx context.Context, portfolioID string, amount float64) error {
+	now := time.Now().UTC()
+	cc, err := s.crashCapital.GetByPortfolioID(ctx, portfolioID)
+	switch {
+	case errors.Is(err, shared.ErrNotFound):
+		cc = &crashplaybook.CrashCapital{
+			ID:          shared.NewID(),
+			PortfolioID: portfolioID,
+			Amount:      amount,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+	case err != nil:
+		return err
+	default:
+		cc.Amount = amount
+		cc.UpdatedAt = now
+	}
+	return s.crashCapital.Upsert(ctx, cc)
+}
+
+// GetDeploymentPlan computes the capital allocation per crash level.
+func (s *CrashPlaybookService) GetDeploymentPlan(ctx context.Context, portfolioID string) (*DeploymentPlan, error) {
+	cc, err := s.GetCrashCapital(ctx, portfolioID)
+	if err != nil {
+		return nil, err
+	}
+
+	deployPcts := s.readDeployPcts(ctx)
+
+	remaining := cc.Amount - cc.Deployed
+	if remaining < 0 {
+		remaining = 0
+	}
+
+	levels := []DeploymentLevelPlan{
+		{Level: crashplaybook.LevelNormalDip, Pct: deployPcts[0], Amount: cc.Amount * deployPcts[0] / 100},
+		{Level: crashplaybook.LevelCrash, Pct: deployPcts[1], Amount: cc.Amount * deployPcts[1] / 100},
+		{Level: crashplaybook.LevelExtreme, Pct: deployPcts[2], Amount: cc.Amount * deployPcts[2] / 100},
+	}
+
+	return &DeploymentPlan{
+		Total:     cc.Amount,
+		Deployed:  cc.Deployed,
+		Remaining: remaining,
+		Levels:    levels,
+	}, nil
+}
+
+// GetDeploymentSettings reads deployment percentage settings.
+func (s *CrashPlaybookService) GetDeploymentSettings(ctx context.Context) (normal, crash, extreme float64, err error) {
+	normal = s.readFloatSetting(ctx, settingDeployNormal, 30)
+	crash = s.readFloatSetting(ctx, settingDeployCrash, 40)
+	extreme = s.readFloatSetting(ctx, settingDeployExtreme, 30)
+	return normal, crash, extreme, nil
+}
+
+// SaveDeploymentSettings persists deployment percentage settings. Sum must equal 100.
+func (s *CrashPlaybookService) SaveDeploymentSettings(ctx context.Context, normal, crash, extreme float64) error {
+	if math.Abs(normal+crash+extreme-100) > 0.01 {
+		return ErrInvalidDeploymentSum
+	}
+	if err := s.settings.SetSetting(ctx, settingDeployNormal, strconv.FormatFloat(normal, 'f', -1, 64)); err != nil {
+		return err
+	}
+	if err := s.settings.SetSetting(ctx, settingDeployCrash, strconv.FormatFloat(crash, 'f', -1, 64)); err != nil {
+		return err
+	}
+	return s.settings.SetSetting(ctx, settingDeployExtreme, strconv.FormatFloat(extreme, 'f', -1, 64))
+}
+
+// SuggestedRefreshInterval returns the suggested refresh interval in minutes for a market condition.
+func SuggestedRefreshInterval(condition crashplaybook.MarketCondition) int {
+	switch condition {
+	case crashplaybook.MarketCrash:
+		return 180
+	case crashplaybook.MarketCorrection:
+		return 240
+	case crashplaybook.MarketElevated:
+		return 360
+	case crashplaybook.MarketRecovery:
+		return 360
+	default:
+		return 720
+	}
+}
+
+func (s *CrashPlaybookService) readDeployPcts(ctx context.Context) [3]float64 {
+	normal, crash, extreme, err := s.GetDeploymentSettings(ctx)
+	if err != nil {
+		return [3]float64{30, 40, 30}
+	}
+	return [3]float64{normal, crash, extreme}
+}
+
+func (s *CrashPlaybookService) readFloatSetting(ctx context.Context, key string, fallback float64) float64 {
+	val, err := s.settings.GetSetting(ctx, key)
+	if err != nil {
+		return fallback
+	}
+	f, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		return fallback
+	}
+	return f
+}
+
+func (s *CrashPlaybookService) buildMarketStatus(data *stock.Data) *crashplaybook.MarketStatus {
+	drawdown := crashplaybook.DrawdownPct(data.Price, data.High52Week)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	condition := crashplaybook.DetectMarketCondition(data.Price, data.High52Week, s.prevCondition)
+
+	if condition != s.prevCondition && s.refresh != nil {
+		if condition == crashplaybook.MarketNormal {
+			s.refresh.SetIntervalOverride(0)
+		} else {
+			s.refresh.SetIntervalOverride(SuggestedRefreshInterval(condition))
+		}
+	}
+
+	s.prevCondition = condition
+
+	status := &crashplaybook.MarketStatus{
+		Condition:   condition,
+		IHSGPrice:   data.Price,
+		IHSGPeak:    data.High52Week,
+		DrawdownPct: drawdown,
+		FetchedAt:   data.FetchedAt,
+	}
+	s.marketCache = status
+	return status
+}
+
+func (s *CrashPlaybookService) buildStockPlaybook(
+	ctx context.Context,
+	h *portfolio.Holding,
+	rp valuation.RiskProfile,
+	deployPcts [3]float64,
+) (*crashplaybook.StockPlaybook, error) {
+	data, err := s.stockData.GetByTickerAndSource(ctx, h.Ticker, s.provider.Source())
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := evaluate(data, rp)
+	if err != nil {
+		return nil, err
+	}
+
+	levels := crashplaybook.ComputeResponseLevels(result.EntryPrice, data.Low52Week, deployPcts)
+	active := crashplaybook.DetermineActiveLevel(data.Price, levels)
+
+	return &crashplaybook.StockPlaybook{
+		Ticker:       h.Ticker,
+		CurrentPrice: data.Price,
+		EntryPrice:   result.EntryPrice,
+		Levels:       levels,
+		ActiveLevel:  active,
+	}, nil
+}

--- a/backend/usecase/crashplaybook_test.go
+++ b/backend/usecase/crashplaybook_test.go
@@ -1,0 +1,300 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lugassawan/panen/backend/domain/crashplaybook"
+	"github.com/lugassawan/panen/backend/domain/portfolio"
+	"github.com/lugassawan/panen/backend/domain/shared"
+	"github.com/lugassawan/panen/backend/domain/stock"
+)
+
+// mockCrashCapitalRepo is an in-memory crashplaybook.CrashCapitalRepository for testing.
+type mockCrashCapitalRepo struct {
+	mu    sync.Mutex
+	items map[string]*crashplaybook.CrashCapital // keyed by portfolioID
+}
+
+func newMockCrashCapitalRepo() *mockCrashCapitalRepo {
+	return &mockCrashCapitalRepo{items: make(map[string]*crashplaybook.CrashCapital)}
+}
+
+func (r *mockCrashCapitalRepo) Upsert(_ context.Context, cc *crashplaybook.CrashCapital) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.items[cc.PortfolioID] = cc
+	return nil
+}
+
+func (r *mockCrashCapitalRepo) GetByPortfolioID(
+	_ context.Context,
+	portfolioID string,
+) (*crashplaybook.CrashCapital, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cc, ok := r.items[portfolioID]
+	if !ok {
+		return nil, shared.ErrNotFound
+	}
+	return cc, nil
+}
+
+func newTestCrashPlaybookService() (
+	*CrashPlaybookService, *mockStockRepo, *mockPortfolioRepo,
+	*mockHoldingRepo, *mockCrashCapitalRepo,
+) {
+	stockRepo := newMockStockRepo()
+	provider := newMockProvider()
+	portfolioRepo := newMockPortfolioRepo()
+	holdingRepo := newMockHoldingRepo()
+	ccRepo := newMockCrashCapitalRepo()
+	settingsRepo := newMockSettingsRepo()
+
+	// Seed default deployment settings.
+	settingsRepo.kv["crash_deploy_pct_normal"] = "30"
+	settingsRepo.kv["crash_deploy_pct_crash"] = "40"
+	settingsRepo.kv["crash_deploy_pct_extreme"] = "30"
+
+	svc := NewCrashPlaybookService(stockRepo, provider, portfolioRepo, holdingRepo, ccRepo, settingsRepo, nil)
+	return svc, stockRepo, portfolioRepo, holdingRepo, ccRepo
+}
+
+func TestGetMarketStatus(t *testing.T) {
+	svc, stockRepo, _, _, _ := newTestCrashPlaybookService()
+	ctx := context.Background()
+
+	// Seed IHSG data — price within 5% of peak so condition is NORMAL.
+	_ = stockRepo.Upsert(ctx, &stock.Data{
+		ID:         "ihsg-1",
+		Ticker:     "^JKSE",
+		Price:      7200,
+		High52Week: 7500,
+		Low52Week:  6000,
+		FetchedAt:  time.Now().UTC(),
+		Source:     "mock",
+	})
+
+	status, err := svc.GetMarketStatus(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if status.Condition != crashplaybook.MarketNormal {
+		t.Errorf("expected NORMAL, got %v", status.Condition)
+	}
+	if status.IHSGPrice != 7200 {
+		t.Errorf("expected price 7200, got %v", status.IHSGPrice)
+	}
+}
+
+func TestGetMarketStatusCrashCondition(t *testing.T) {
+	svc, stockRepo, _, _, _ := newTestCrashPlaybookService()
+	ctx := context.Background()
+
+	_ = stockRepo.Upsert(ctx, &stock.Data{
+		ID:         "ihsg-1",
+		Ticker:     "^JKSE",
+		Price:      5500,
+		High52Week: 7500,
+		Low52Week:  5000,
+		FetchedAt:  time.Now().UTC(),
+		Source:     "mock",
+	})
+
+	status, err := svc.GetMarketStatus(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if status.Condition != crashplaybook.MarketCrash {
+		t.Errorf("expected CRASH, got %v", status.Condition)
+	}
+}
+
+func TestGetPortfolioPlaybook(t *testing.T) {
+	svc, stockRepo, portfolioRepo, holdingRepo, _ := newTestCrashPlaybookService()
+	ctx := context.Background()
+
+	// Seed IHSG — price within 5% of peak so condition is NORMAL.
+	_ = stockRepo.Upsert(ctx, &stock.Data{
+		ID: "ihsg-1", Ticker: "^JKSE", Price: 7200, High52Week: 7500, Low52Week: 6000,
+		FetchedAt: time.Now().UTC(), Source: "mock",
+	})
+
+	// Seed portfolio + holding + stock data.
+	_ = portfolioRepo.Create(ctx, &portfolio.Portfolio{
+		ID: "p1", BrokerageAccountID: "b1", Name: "Test",
+		Mode: "VALUE", RiskProfile: "CONSERVATIVE",
+	})
+	_ = holdingRepo.Create(ctx, &portfolio.Holding{
+		ID: "h1", PortfolioID: "p1", Ticker: "BBCA", AvgBuyPrice: 8000, Lots: 10,
+	})
+	_ = stockRepo.Upsert(ctx, &stock.Data{
+		ID: "bbca-1", Ticker: "BBCA", Price: 8500, High52Week: 9000, Low52Week: 7000,
+		EPS: 500, BVPS: 3000, FetchedAt: time.Now().UTC(), Source: "mock",
+	})
+
+	pb, err := svc.GetPortfolioPlaybook(ctx, "p1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if pb.Market.Condition != crashplaybook.MarketNormal {
+		t.Errorf("expected NORMAL market, got %v", pb.Market.Condition)
+	}
+	if len(pb.Stocks) != 1 {
+		t.Fatalf("expected 1 stock playbook, got %d", len(pb.Stocks))
+	}
+	if pb.Stocks[0].Ticker != "BBCA" {
+		t.Errorf("expected ticker BBCA, got %v", pb.Stocks[0].Ticker)
+	}
+	if len(pb.Stocks[0].Levels) != 3 {
+		t.Errorf("expected 3 levels, got %d", len(pb.Stocks[0].Levels))
+	}
+}
+
+func TestSaveCrashCapital(t *testing.T) {
+	svc, _, _, _, ccRepo := newTestCrashPlaybookService()
+	ctx := context.Background()
+
+	if err := svc.SaveCrashCapital(ctx, "p1", 10_000_000); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cc, err := ccRepo.GetByPortfolioID(ctx, "p1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cc.Amount != 10_000_000 {
+		t.Errorf("expected amount 10000000, got %v", cc.Amount)
+	}
+
+	// Update existing.
+	if err := svc.SaveCrashCapital(ctx, "p1", 20_000_000); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cc, _ = ccRepo.GetByPortfolioID(ctx, "p1")
+	if cc.Amount != 20_000_000 {
+		t.Errorf("expected amount 20000000, got %v", cc.Amount)
+	}
+}
+
+func TestGetDeploymentPlan(t *testing.T) {
+	svc, _, _, _, _ := newTestCrashPlaybookService()
+	ctx := context.Background()
+
+	_ = svc.SaveCrashCapital(ctx, "p1", 10_000_000)
+
+	plan, err := svc.GetDeploymentPlan(ctx, "p1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if plan.Total != 10_000_000 {
+		t.Errorf("expected total 10000000, got %v", plan.Total)
+	}
+	if len(plan.Levels) != 3 {
+		t.Fatalf("expected 3 levels, got %d", len(plan.Levels))
+	}
+	if plan.Levels[0].Amount != 3_000_000 {
+		t.Errorf("expected normal dip amount 3000000, got %v", plan.Levels[0].Amount)
+	}
+	if plan.Levels[1].Amount != 4_000_000 {
+		t.Errorf("expected crash amount 4000000, got %v", plan.Levels[1].Amount)
+	}
+	if plan.Levels[2].Amount != 3_000_000 {
+		t.Errorf("expected extreme amount 3000000, got %v", plan.Levels[2].Amount)
+	}
+}
+
+func TestSaveDeploymentSettingsValidSum(t *testing.T) {
+	svc, _, _, _, _ := newTestCrashPlaybookService()
+	ctx := context.Background()
+
+	if err := svc.SaveDeploymentSettings(ctx, 20, 50, 30); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	normal, crash, extreme, err := svc.GetDeploymentSettings(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if normal != 20 || crash != 50 || extreme != 30 {
+		t.Errorf("expected 20/50/30, got %v/%v/%v", normal, crash, extreme)
+	}
+}
+
+func TestSaveDeploymentSettingsInvalidSum(t *testing.T) {
+	svc, _, _, _, _ := newTestCrashPlaybookService()
+	ctx := context.Background()
+
+	err := svc.SaveDeploymentSettings(ctx, 20, 50, 20)
+	if !errors.Is(err, ErrInvalidDeploymentSum) {
+		t.Errorf("expected ErrInvalidDeploymentSum, got %v", err)
+	}
+}
+
+func TestSuggestedRefreshInterval(t *testing.T) {
+	tests := []struct {
+		condition crashplaybook.MarketCondition
+		want      int
+	}{
+		{crashplaybook.MarketNormal, 720},
+		{crashplaybook.MarketElevated, 360},
+		{crashplaybook.MarketCorrection, 240},
+		{crashplaybook.MarketCrash, 180},
+		{crashplaybook.MarketRecovery, 360},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.condition), func(t *testing.T) {
+			got := SuggestedRefreshInterval(tt.condition)
+			if got != tt.want {
+				t.Errorf("SuggestedRefreshInterval(%v) = %v, want %v", tt.condition, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetDiagnostic(t *testing.T) {
+	svc, stockRepo, portfolioRepo, _, _ := newTestCrashPlaybookService()
+	ctx := context.Background()
+
+	// Seed IHSG in crash condition.
+	_ = stockRepo.Upsert(ctx, &stock.Data{
+		ID: "ihsg-1", Ticker: "^JKSE", Price: 5500, High52Week: 7500, Low52Week: 5000,
+		FetchedAt: time.Now().UTC(), Source: "mock",
+	})
+
+	_ = portfolioRepo.Create(ctx, &portfolio.Portfolio{
+		ID: "p1", BrokerageAccountID: "b1", Name: "Test",
+		Mode: "VALUE", RiskProfile: "CONSERVATIVE",
+	})
+
+	// Seed stock data where price is below entry.
+	_ = stockRepo.Upsert(ctx, &stock.Data{
+		ID: "bbca-1", Ticker: "BBCA", Price: 500, High52Week: 9000, Low52Week: 400,
+		EPS: 500, BVPS: 3000, FetchedAt: time.Now().UTC(), Source: "mock",
+	})
+
+	boolPtr := func(v bool) *bool { return &v }
+
+	diag, err := svc.GetDiagnostic(ctx, "BBCA", "p1", boolPtr(false), boolPtr(true))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !diag.MarketCrashed {
+		t.Error("expected marketCrashed to be true")
+	}
+	if !diag.BelowEntry {
+		t.Error("expected belowEntry to be true")
+	}
+	if diag.Signal != crashplaybook.SignalOpportunity {
+		t.Errorf("expected OPPORTUNITY signal, got %v", diag.Signal)
+	}
+}

--- a/backend/usecase/refresh.go
+++ b/backend/usecase/refresh.go
@@ -64,11 +64,12 @@ type RefreshService struct {
 	collector TickerCollector
 	emitter   EventEmitter
 
-	mu      sync.Mutex
-	status  RefreshStatus
-	running atomic.Bool
-	cancel  context.CancelFunc
-	done    chan struct{}
+	mu               sync.Mutex
+	status           RefreshStatus
+	running          atomic.Bool
+	cancel           context.CancelFunc
+	done             chan struct{}
+	intervalOverride int // minutes, 0 = no override
 }
 
 // NewRefreshService creates a new RefreshService.
@@ -113,6 +114,14 @@ func (r *RefreshService) RunNow(ctx context.Context) error {
 	return r.refresh(ctx)
 }
 
+// SetIntervalOverride sets a temporary interval override in minutes.
+// Pass 0 to clear the override.
+func (r *RefreshService) SetIntervalOverride(minutes int) {
+	r.mu.Lock()
+	r.intervalOverride = minutes
+	r.mu.Unlock()
+}
+
 // GetStatus returns the current refresh status (thread-safe).
 func (r *RefreshService) GetStatus() RefreshStatus {
 	r.mu.Lock()
@@ -147,22 +156,40 @@ func (r *RefreshService) loop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			cfg, err := r.settings.GetRefreshSettings(ctx)
-			if err != nil || !cfg.AutoRefreshEnabled {
+			if !r.shouldRefresh(ctx) {
 				continue
 			}
-
-			newInterval := time.Duration(cfg.IntervalMinutes) * time.Minute
-			if newInterval > 0 && newInterval != interval {
+			if newInterval := r.effectiveInterval(ctx); newInterval > 0 && newInterval != interval {
 				interval = newInterval
 				ticker.Reset(interval)
 			}
-
 			if err := r.refresh(ctx); err != nil {
 				r.emitter.Emit(eventRefreshError, err.Error())
 			}
 		}
 	}
+}
+
+func (r *RefreshService) shouldRefresh(ctx context.Context) bool {
+	cfg, err := r.settings.GetRefreshSettings(ctx)
+	return err == nil && cfg.AutoRefreshEnabled
+}
+
+func (r *RefreshService) effectiveInterval(ctx context.Context) time.Duration {
+	cfg, err := r.settings.GetRefreshSettings(ctx)
+	if err != nil {
+		return 0
+	}
+	interval := time.Duration(cfg.IntervalMinutes) * time.Minute
+	r.mu.Lock()
+	override := r.intervalOverride
+	r.mu.Unlock()
+	if override > 0 {
+		if ov := time.Duration(override) * time.Minute; ov < interval {
+			interval = ov
+		}
+	}
+	return interval
 }
 
 func (r *RefreshService) setStatus(s RefreshStatus) {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -3,6 +3,7 @@ import Sidebar from "./components/Sidebar.svelte";
 import { theme } from "./lib/stores/theme.svelte";
 import type { Page } from "./lib/types";
 import BrokeragePage from "./pages/brokerage/BrokeragePage.svelte";
+import CrashPlaybookPage from "./pages/crashplaybook/CrashPlaybookPage.svelte";
 import PaydayPage from "./pages/payday/PaydayPage.svelte";
 import PortfolioPage from "./pages/portfolio/PortfolioPage.svelte";
 import SettingsPage from "./pages/settings/SettingsPage.svelte";
@@ -24,6 +25,8 @@ let currentPage = $state<Page>("lookup");
       <PortfolioPage />
     {:else if currentPage === "payday"}
       <PaydayPage />
+    {:else if currentPage === "crashplaybook"}
+      <CrashPlaybookPage />
     {:else if currentPage === "brokerage"}
       <BrokeragePage />
     {:else if currentPage === "settings"}

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -64,17 +64,18 @@ vi.mock("./lib/stores/theme.svelte", () => ({
 }));
 
 describe("App navigation", () => {
-  it("renders sidebar with 6 nav items", () => {
+  it("renders sidebar with 7 nav items", () => {
     render(App);
     const nav = screen.getByRole("navigation", { name: /main/i });
     const buttons = within(nav).getAllByRole("button");
-    expect(buttons).toHaveLength(6);
+    expect(buttons).toHaveLength(7);
     expect(buttons[0]).toHaveTextContent("Stock Lookup");
     expect(buttons[1]).toHaveTextContent("Watchlist");
     expect(buttons[2]).toHaveTextContent("Portfolio");
     expect(buttons[3]).toHaveTextContent("Payday");
-    expect(buttons[4]).toHaveTextContent("Brokerage");
-    expect(buttons[5]).toHaveTextContent("Settings");
+    expect(buttons[4]).toHaveTextContent("Crash Playbook");
+    expect(buttons[5]).toHaveTextContent("Brokerage");
+    expect(buttons[6]).toHaveTextContent("Settings");
   });
 
   it("starts on Stock Lookup page by default", () => {

--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
-import { Bookmark, Briefcase, CalendarDays, Landmark, Search, Settings } from "lucide-svelte";
+import {
+  Bookmark,
+  Briefcase,
+  CalendarDays,
+  Landmark,
+  Search,
+  Settings,
+  Shield,
+} from "lucide-svelte";
 import type { Component } from "svelte";
 import SyncIndicator from "../lib/components/SyncIndicator.svelte";
 import type { Page } from "../lib/types";
@@ -11,6 +19,7 @@ const navItems: { page: Page; label: string; icon: Component }[] = [
   { page: "watchlist", label: "Watchlist", icon: Bookmark },
   { page: "portfolio", label: "Portfolio", icon: Briefcase },
   { page: "payday", label: "Payday", icon: CalendarDays },
+  { page: "crashplaybook", label: "Crash Playbook", icon: Shield },
   { page: "brokerage", label: "Brokerage", icon: Landmark },
   { page: "settings", label: "Settings", icon: Settings },
 ];

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -88,7 +88,14 @@ export type RiskProfile = "CONSERVATIVE" | "MODERATE" | "AGGRESSIVE";
 
 export type Verdict = "UNDERVALUED" | "FAIR" | "OVERVALUED";
 
-export type Page = "lookup" | "watchlist" | "portfolio" | "payday" | "brokerage" | "settings";
+export type Page =
+  | "lookup"
+  | "watchlist"
+  | "portfolio"
+  | "payday"
+  | "crashplaybook"
+  | "brokerage"
+  | "settings";
 
 export type PaydayStatus = "SCHEDULED" | "PENDING" | "CONFIRMED" | "DEFERRED" | "SKIPPED";
 
@@ -124,6 +131,73 @@ export interface CashFlowItemResponse {
   date: string;
   note: string;
   createdAt: string;
+}
+
+export type MarketCondition = "NORMAL" | "ELEVATED" | "CORRECTION" | "CRASH" | "RECOVERY";
+
+export type CrashLevel = "NORMAL_DIP" | "CRASH" | "EXTREME";
+
+export type DiagnosticSignal = "OPPORTUNITY" | "FALLING_KNIFE" | "INCONCLUSIVE";
+
+export interface MarketStatusResponse {
+  condition: MarketCondition;
+  ihsgPrice: number;
+  ihsgPeak: number;
+  drawdownPct: number;
+  fetchedAt: string;
+}
+
+export interface ResponseLevelResponse {
+  level: CrashLevel;
+  triggerPrice: number;
+  deployPct: number;
+}
+
+export interface StockPlaybookResponse {
+  ticker: string;
+  currentPrice: number;
+  entryPrice: number;
+  levels: ResponseLevelResponse[];
+  activeLevel?: CrashLevel;
+}
+
+export interface PortfolioPlaybookResponse {
+  market: MarketStatusResponse;
+  stocks: StockPlaybookResponse[];
+  refreshMin: number;
+}
+
+export interface DiagnosticResponse {
+  marketCrashed: boolean;
+  companyBadNews: boolean | null;
+  fundamentalsOK: boolean | null;
+  belowEntry: boolean;
+  signal: DiagnosticSignal;
+}
+
+export interface CrashCapitalResponse {
+  portfolioId: string;
+  amount: number;
+  deployed: number;
+}
+
+export interface DeploymentLevelPlanResponse {
+  level: CrashLevel;
+  pct: number;
+  amount: number;
+}
+
+export interface DeploymentPlanResponse {
+  total: number;
+  deployed: number;
+  remaining: number;
+  levels: DeploymentLevelPlanResponse[];
+}
+
+export interface DeploymentSettingsResponse {
+  normal: number;
+  crash: number;
+  extreme: number;
 }
 
 export interface WatchlistResponse {

--- a/frontend/src/pages/crashplaybook/CrashCapitalPanel.svelte
+++ b/frontend/src/pages/crashplaybook/CrashCapitalPanel.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+import Button from "../../lib/components/Button.svelte";
+import Input from "../../lib/components/Input.svelte";
+import { formatRupiah } from "../../lib/format";
+import type { CrashCapitalResponse, DeploymentPlanResponse } from "../../lib/types";
+
+let {
+  capital,
+  plan,
+  onSave,
+  onOpenSettings,
+}: {
+  capital: CrashCapitalResponse;
+  plan: DeploymentPlanResponse | null;
+  onSave: (amount: number) => void;
+  onOpenSettings: () => void;
+} = $props();
+
+let amountStr = $state(capital.amount > 0 ? String(capital.amount) : "");
+
+function handleSave() {
+  const amount = Number(amountStr);
+  if (!Number.isNaN(amount) && amount >= 0) {
+    onSave(amount);
+  }
+}
+</script>
+
+<div class="rounded-lg border border-border-default bg-bg-elevated p-4">
+  <div class="flex items-center justify-between">
+    <h3 class="font-display text-base font-semibold text-text-primary">Crash Capital</h3>
+    <button
+      class="text-xs text-text-secondary underline transition-fast hover:text-text-primary focus-ring rounded"
+      onclick={onOpenSettings}
+    >
+      Deployment Settings
+    </button>
+  </div>
+
+  <div class="mt-3 flex items-end gap-3">
+    <label class="flex-1">
+      <span class="block text-xs font-medium text-text-secondary mb-1">Reserved Amount (Rp)</span>
+      <Input
+        type="number"
+        bind:value={amountStr}
+        placeholder="e.g. 10000000"
+      />
+    </label>
+    <Button variant="primary" size="sm" onclick={handleSave}>Save</Button>
+  </div>
+
+  {#if plan}
+    <div class="mt-4 space-y-2">
+      <div class="flex items-center justify-between text-sm">
+        <span class="text-text-secondary">Total Reserved</span>
+        <span class="font-mono font-medium text-text-primary">{formatRupiah(plan.total)}</span>
+      </div>
+      <div class="flex items-center justify-between text-sm">
+        <span class="text-text-secondary">Deployed</span>
+        <span class="font-mono font-medium text-text-primary">{formatRupiah(plan.deployed)}</span>
+      </div>
+      <div class="flex items-center justify-between text-sm">
+        <span class="text-text-secondary">Remaining</span>
+        <span class="font-mono font-medium text-profit">{formatRupiah(plan.remaining)}</span>
+      </div>
+
+      <hr class="border-border-default" />
+
+      {#each plan.levels as level}
+        <div class="flex items-center justify-between text-sm">
+          <span class="text-text-secondary">{level.level.replace("_", " ")} ({level.pct}%)</span>
+          <span class="font-mono text-text-primary">{formatRupiah(level.amount)}</span>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/frontend/src/pages/crashplaybook/CrashCapitalPanel.test.ts
+++ b/frontend/src/pages/crashplaybook/CrashCapitalPanel.test.ts
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { CrashCapitalResponse, DeploymentPlanResponse } from "../../lib/types";
+import CrashCapitalPanel from "./CrashCapitalPanel.svelte";
+
+function makeCapital(): CrashCapitalResponse {
+  return { portfolioId: "p1", amount: 10000000, deployed: 0 };
+}
+
+function makePlan(): DeploymentPlanResponse {
+  return {
+    total: 10000000,
+    deployed: 0,
+    remaining: 10000000,
+    levels: [
+      { level: "NORMAL_DIP", pct: 30, amount: 3000000 },
+      { level: "CRASH", pct: 40, amount: 4000000 },
+      { level: "EXTREME", pct: 30, amount: 3000000 },
+    ],
+  };
+}
+
+describe("CrashCapitalPanel", () => {
+  it("renders crash capital heading", () => {
+    render(CrashCapitalPanel, {
+      props: { capital: makeCapital(), plan: makePlan(), onSave: vi.fn(), onOpenSettings: vi.fn() },
+    });
+    expect(screen.getByText("Crash Capital")).toBeTruthy();
+  });
+
+  it("shows deployment breakdown", () => {
+    render(CrashCapitalPanel, {
+      props: { capital: makeCapital(), plan: makePlan(), onSave: vi.fn(), onOpenSettings: vi.fn() },
+    });
+    expect(document.body.textContent).toContain("3.000.000");
+    expect(document.body.textContent).toContain("4.000.000");
+  });
+
+  it("shows Deployment Settings link", () => {
+    render(CrashCapitalPanel, {
+      props: { capital: makeCapital(), plan: makePlan(), onSave: vi.fn(), onOpenSettings: vi.fn() },
+    });
+    expect(screen.getByText("Deployment Settings")).toBeTruthy();
+  });
+
+  it("calls onOpenSettings when link is clicked", async () => {
+    const onOpenSettings = vi.fn();
+    render(CrashCapitalPanel, {
+      props: { capital: makeCapital(), plan: makePlan(), onSave: vi.fn(), onOpenSettings },
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Deployment Settings"));
+    expect(onOpenSettings).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/crashplaybook/CrashPlaybookPage.svelte
+++ b/frontend/src/pages/crashplaybook/CrashPlaybookPage.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+import {
+  GetCrashCapital,
+  GetDeploymentPlan,
+  GetDeploymentSettings,
+  GetDiagnostic,
+  GetPortfolioPlaybook,
+  ListAllPortfolios,
+  SaveCrashCapital,
+  SaveDeploymentSettings,
+} from "../../../wailsjs/go/backend/App";
+import Button from "../../lib/components/Button.svelte";
+import Select from "../../lib/components/Select.svelte";
+import type {
+  CrashCapitalResponse,
+  DeploymentPlanResponse,
+  DeploymentSettingsResponse,
+  DiagnosticResponse,
+  PortfolioPlaybookResponse,
+  PortfolioResponse,
+} from "../../lib/types";
+import CrashCapitalPanel from "./CrashCapitalPanel.svelte";
+import DeploymentSettings from "./DeploymentSettings.svelte";
+import FallingKnifeDialog from "./FallingKnifeDialog.svelte";
+import MarketStatusBanner from "./MarketStatusBanner.svelte";
+import StockPlaybookCard from "./StockPlaybookCard.svelte";
+
+type PageState = "loading" | "ready" | "empty" | "error";
+
+let state = $state<PageState>("loading");
+let error = $state<string | null>(null);
+let portfolios = $state<PortfolioResponse[]>([]);
+let selectedPortfolioId = $state<string>("");
+let playbook = $state<PortfolioPlaybookResponse | null>(null);
+let capital = $state<CrashCapitalResponse | null>(null);
+let deploymentPlan = $state<DeploymentPlanResponse | null>(null);
+let deploymentSettings = $state<DeploymentSettingsResponse | null>(null);
+
+let diagnosticTicker = $state<string | null>(null);
+let diagnosticResult = $state<DiagnosticResponse | null>(null);
+let showSettings = $state(false);
+
+async function loadPortfolios() {
+  try {
+    state = "loading";
+    error = null;
+    const list = await ListAllPortfolios();
+    portfolios = list ?? [];
+    if (portfolios.length === 0) {
+      state = "empty";
+      return;
+    }
+    if (!selectedPortfolioId || !portfolios.find((p) => p.id === selectedPortfolioId)) {
+      selectedPortfolioId = portfolios[0].id;
+    }
+    await loadPlaybook();
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+    state = "error";
+  }
+}
+
+async function loadPlaybook() {
+  try {
+    state = "loading";
+    error = null;
+    const [pb, cc, dp] = await Promise.all([
+      GetPortfolioPlaybook(selectedPortfolioId),
+      GetCrashCapital(selectedPortfolioId),
+      GetDeploymentPlan(selectedPortfolioId),
+    ]);
+    playbook = pb;
+    capital = cc;
+    deploymentPlan = dp;
+    state = "ready";
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+    state = "error";
+  }
+}
+
+async function handlePortfolioChange(e: Event & { currentTarget: HTMLSelectElement }) {
+  selectedPortfolioId = e.currentTarget.value;
+  await loadPlaybook();
+}
+
+async function handleSaveCapital(amount: number) {
+  try {
+    await SaveCrashCapital(selectedPortfolioId, amount);
+    capital = await GetCrashCapital(selectedPortfolioId);
+    deploymentPlan = await GetDeploymentPlan(selectedPortfolioId);
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+}
+
+async function handleDiagnostic(ticker: string) {
+  try {
+    diagnosticTicker = ticker;
+    diagnosticResult = await GetDiagnostic(ticker, selectedPortfolioId, null, null);
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+}
+
+async function handleDiagnosticUpdate(
+  companyBadNews: boolean | null,
+  fundamentalsOK: boolean | null,
+) {
+  if (!diagnosticTicker) return;
+  try {
+    diagnosticResult = await GetDiagnostic(
+      diagnosticTicker,
+      selectedPortfolioId,
+      companyBadNews,
+      fundamentalsOK,
+    );
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+}
+
+async function handleOpenSettings() {
+  try {
+    deploymentSettings = await GetDeploymentSettings();
+    showSettings = true;
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+}
+
+async function handleSaveSettings(normal: number, crash: number, extreme: number) {
+  try {
+    await SaveDeploymentSettings(normal, crash, extreme);
+    showSettings = false;
+    await loadPlaybook();
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+}
+
+$effect(() => {
+  loadPortfolios();
+});
+</script>
+
+<div class="p-6">
+  <h1 class="font-display text-2xl font-bold text-text-primary">Crash Playbook</h1>
+  <p class="mt-1 text-sm text-text-secondary">Pre-calculated crash response levels for your holdings.</p>
+
+  {#if state === "loading"}
+    <div class="flex items-center justify-center py-16">
+      <p class="text-sm text-text-secondary">Loading...</p>
+    </div>
+  {:else if state === "error"}
+    <div class="mt-6 rounded-lg border border-negative bg-negative-bg p-4">
+      <p class="text-sm text-negative">{error}</p>
+      <div class="mt-3">
+        <Button variant="secondary" size="sm" onclick={loadPortfolios}>Retry</Button>
+      </div>
+    </div>
+  {:else if state === "empty"}
+    <div class="mt-6 text-center text-sm text-text-secondary">
+      No portfolios found. Create a portfolio first.
+    </div>
+  {:else if state === "ready" && playbook}
+    <div class="mt-4">
+      <Select value={selectedPortfolioId} onchange={handlePortfolioChange} aria-label="Select portfolio">
+        {#each portfolios as p}
+          <option value={p.id}>{p.name}</option>
+        {/each}
+      </Select>
+    </div>
+
+    <div class="mt-4">
+      <MarketStatusBanner market={playbook.market} />
+    </div>
+
+    {#if playbook.market.condition !== "NORMAL"}
+      <div class="mt-2 text-xs text-text-secondary">
+        Refresh interval: every {Math.floor(playbook.refreshMin / 60)}h (auto-adjusted)
+      </div>
+    {/if}
+
+    {#if playbook.stocks.length > 0}
+      <div class="mt-4 grid gap-4 md:grid-cols-2">
+        {#each playbook.stocks as stock}
+          <StockPlaybookCard {stock} onDiagnostic={handleDiagnostic} />
+        {/each}
+      </div>
+    {:else}
+      <div class="mt-6 text-center text-sm text-text-secondary">
+        No holdings with stock data. Add holdings to your portfolio first.
+      </div>
+    {/if}
+
+    {#if capital}
+      <div class="mt-6">
+        <CrashCapitalPanel
+          {capital}
+          plan={deploymentPlan}
+          onSave={handleSaveCapital}
+          onOpenSettings={handleOpenSettings}
+        />
+      </div>
+    {/if}
+  {/if}
+</div>
+
+{#if diagnosticTicker && diagnosticResult}
+  <FallingKnifeDialog
+    ticker={diagnosticTicker}
+    diagnostic={diagnosticResult}
+    onUpdate={handleDiagnosticUpdate}
+    onClose={() => { diagnosticTicker = null; diagnosticResult = null; }}
+  />
+{/if}
+
+{#if showSettings && deploymentSettings}
+  <DeploymentSettings
+    settings={deploymentSettings}
+    onSave={handleSaveSettings}
+    onClose={() => { showSettings = false; }}
+  />
+{/if}

--- a/frontend/src/pages/crashplaybook/DeploymentSettings.svelte
+++ b/frontend/src/pages/crashplaybook/DeploymentSettings.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+import Button from "../../lib/components/Button.svelte";
+import Input from "../../lib/components/Input.svelte";
+import type { DeploymentSettingsResponse } from "../../lib/types";
+
+let {
+  settings,
+  onSave,
+  onClose,
+}: {
+  settings: DeploymentSettingsResponse;
+  onSave: (normal: number, crash: number, extreme: number) => void;
+  onClose: () => void;
+} = $props();
+
+let normal = $state(String(settings.normal));
+let crash = $state(String(settings.crash));
+let extreme = $state(String(settings.extreme));
+
+const sum = $derived(Number(normal) + Number(crash) + Number(extreme));
+const isValid = $derived(sum === 100);
+
+function handleSave() {
+  if (isValid) {
+    onSave(Number(normal), Number(crash), Number(extreme));
+  }
+}
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
+<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onclick={onClose}>
+  <!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
+  <div class="w-full max-w-sm rounded-lg border border-border-default bg-bg-elevated p-6" onclick={(e) => e.stopPropagation()}>
+    <h3 class="font-display text-lg font-semibold text-text-primary">Deployment Settings</h3>
+    <p class="mt-1 text-sm text-text-secondary">Set capital deployment % per crash level. Must sum to 100%.</p>
+
+    <div class="mt-4 space-y-3">
+      <label class="block">
+        <span class="block text-xs font-medium text-text-secondary mb-1">Normal Dip (%)</span>
+        <Input type="number" bind:value={normal} />
+      </label>
+      <label class="block">
+        <span class="block text-xs font-medium text-text-secondary mb-1">Crash (%)</span>
+        <Input type="number" bind:value={crash} />
+      </label>
+      <label class="block">
+        <span class="block text-xs font-medium text-text-secondary mb-1">Extreme (%)</span>
+        <Input type="number" bind:value={extreme} />
+      </label>
+    </div>
+
+    <div class="mt-3 text-sm {isValid ? 'text-profit' : 'text-loss'}">
+      Total: {sum}% {isValid ? "" : "(must be 100%)"}
+    </div>
+
+    <div class="mt-4 flex items-center justify-end gap-3">
+      <Button variant="secondary" size="sm" onclick={onClose}>Cancel</Button>
+      <Button variant="primary" size="sm" onclick={handleSave} disabled={!isValid}>Save</Button>
+    </div>
+  </div>
+</div>

--- a/frontend/src/pages/crashplaybook/DeploymentSettings.test.ts
+++ b/frontend/src/pages/crashplaybook/DeploymentSettings.test.ts
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { DeploymentSettingsResponse } from "../../lib/types";
+import DeploymentSettings from "./DeploymentSettings.svelte";
+
+function makeSettings(): DeploymentSettingsResponse {
+  return { normal: 30, crash: 40, extreme: 30 };
+}
+
+describe("DeploymentSettings", () => {
+  it("renders heading and description", () => {
+    render(DeploymentSettings, {
+      props: { settings: makeSettings(), onSave: vi.fn(), onClose: vi.fn() },
+    });
+    expect(screen.getByText("Deployment Settings")).toBeTruthy();
+    expect(screen.getByText(/Must sum to 100%/)).toBeTruthy();
+  });
+
+  it("shows total as valid when sum is 100", () => {
+    render(DeploymentSettings, {
+      props: { settings: makeSettings(), onSave: vi.fn(), onClose: vi.fn() },
+    });
+    expect(document.body.textContent).toContain("Total: 100%");
+  });
+
+  it("disables save when sum is not 100", async () => {
+    const settings = { normal: 20, crash: 40, extreme: 30 };
+    render(DeploymentSettings, {
+      props: { settings, onSave: vi.fn(), onClose: vi.fn() },
+    });
+    const saveButton = screen.getByText("Save");
+    expect(saveButton).toHaveProperty("disabled", true);
+  });
+
+  it("calls onClose when Cancel is clicked", async () => {
+    const onClose = vi.fn();
+    render(DeploymentSettings, {
+      props: { settings: makeSettings(), onSave: vi.fn(), onClose },
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Cancel"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onSave with values when Save is clicked", async () => {
+    const onSave = vi.fn();
+    render(DeploymentSettings, {
+      props: { settings: makeSettings(), onSave, onClose: vi.fn() },
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Save"));
+    expect(onSave).toHaveBeenCalledWith(30, 40, 30);
+  });
+});

--- a/frontend/src/pages/crashplaybook/FallingKnifeDialog.svelte
+++ b/frontend/src/pages/crashplaybook/FallingKnifeDialog.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+import Badge from "../../lib/components/Badge.svelte";
+import Button from "../../lib/components/Button.svelte";
+import type { DiagnosticResponse, DiagnosticSignal } from "../../lib/types";
+
+let {
+  ticker,
+  diagnostic,
+  onUpdate,
+  onClose,
+}: {
+  ticker: string;
+  diagnostic: DiagnosticResponse;
+  onUpdate: (companyBadNews: boolean | null, fundamentalsOK: boolean | null) => void;
+  onClose: () => void;
+} = $props();
+
+let companyBadNews = $state<boolean | null>(diagnostic.companyBadNews);
+let fundamentalsOK = $state<boolean | null>(diagnostic.fundamentalsOK);
+
+function toggleCompanyBadNews() {
+  companyBadNews = companyBadNews === null ? true : companyBadNews ? false : null;
+  onUpdate(companyBadNews, fundamentalsOK);
+}
+
+function toggleFundamentalsOK() {
+  fundamentalsOK = fundamentalsOK === null ? true : fundamentalsOK ? false : null;
+  onUpdate(companyBadNews, fundamentalsOK);
+}
+
+const signalConfig: Record<
+  DiagnosticSignal,
+  { variant: "profit" | "loss" | "warning"; label: string }
+> = {
+  OPPORTUNITY: { variant: "profit", label: "Opportunity" },
+  FALLING_KNIFE: { variant: "loss", label: "Falling Knife" },
+  INCONCLUSIVE: { variant: "warning", label: "Inconclusive" },
+};
+
+const signal = $derived(signalConfig[diagnostic.signal]);
+
+function checkColor(value: boolean | null, invertMeaning = false): string {
+  if (value === null) return "text-text-secondary";
+  const pass = invertMeaning ? !value : value;
+  return pass ? "text-profit" : "text-loss";
+}
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
+<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onclick={onClose}>
+  <!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
+  <div class="w-full max-w-md rounded-lg border border-border-default bg-bg-elevated p-6" onclick={(e) => e.stopPropagation()}>
+    <div class="flex items-center justify-between">
+      <h3 class="font-display text-lg font-semibold text-text-primary">Falling Knife Diagnostic</h3>
+      <Badge variant={signal.variant}>{signal.label}</Badge>
+    </div>
+    <p class="mt-1 text-sm text-text-secondary">
+      Evaluating <span class="font-mono font-medium text-text-primary">{ticker}</span>
+    </p>
+
+    <div class="mt-4 space-y-3">
+      <div class="flex items-center justify-between rounded-md bg-bg-primary px-3 py-2">
+        <span class="text-sm text-text-secondary">Broad market crashed?</span>
+        <span class="font-mono text-sm font-medium {diagnostic.marketCrashed ? 'text-loss' : 'text-profit'}">
+          {diagnostic.marketCrashed ? "Yes" : "No"}
+        </span>
+      </div>
+
+      <button
+        class="flex w-full items-center justify-between rounded-md bg-bg-primary px-3 py-2 transition-fast hover:bg-bg-tertiary focus-ring"
+        onclick={toggleCompanyBadNews}
+      >
+        <span class="text-sm text-text-secondary">Company-specific bad news?</span>
+        <span class="font-mono text-sm font-medium {checkColor(companyBadNews, true)}">
+          {companyBadNews === null ? "Unknown" : companyBadNews ? "Yes" : "No"}
+        </span>
+      </button>
+
+      <button
+        class="flex w-full items-center justify-between rounded-md bg-bg-primary px-3 py-2 transition-fast hover:bg-bg-tertiary focus-ring"
+        onclick={toggleFundamentalsOK}
+      >
+        <span class="text-sm text-text-secondary">Fundamentals still healthy?</span>
+        <span class="font-mono text-sm font-medium {checkColor(fundamentalsOK)}">
+          {fundamentalsOK === null ? "Unknown" : fundamentalsOK ? "Yes" : "No"}
+        </span>
+      </button>
+
+      <div class="flex items-center justify-between rounded-md bg-bg-primary px-3 py-2">
+        <span class="text-sm text-text-secondary">Price below entry target?</span>
+        <span class="font-mono text-sm font-medium {diagnostic.belowEntry ? 'text-profit' : 'text-text-secondary'}">
+          {diagnostic.belowEntry ? "Yes" : "No"}
+        </span>
+      </div>
+    </div>
+
+    <div class="mt-4 flex justify-end">
+      <Button variant="secondary" size="sm" onclick={onClose}>Close</Button>
+    </div>
+  </div>
+</div>

--- a/frontend/src/pages/crashplaybook/FallingKnifeDialog.test.ts
+++ b/frontend/src/pages/crashplaybook/FallingKnifeDialog.test.ts
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { DiagnosticResponse } from "../../lib/types";
+import FallingKnifeDialog from "./FallingKnifeDialog.svelte";
+
+function makeDiagnostic(overrides: Partial<DiagnosticResponse> = {}): DiagnosticResponse {
+  return {
+    marketCrashed: true,
+    companyBadNews: null,
+    fundamentalsOK: null,
+    belowEntry: true,
+    signal: "INCONCLUSIVE",
+    ...overrides,
+  };
+}
+
+describe("FallingKnifeDialog", () => {
+  it("renders ticker and signal badge", () => {
+    render(FallingKnifeDialog, {
+      props: {
+        ticker: "BBCA",
+        diagnostic: makeDiagnostic(),
+        onUpdate: vi.fn(),
+        onClose: vi.fn(),
+      },
+    });
+    expect(screen.getByText("BBCA")).toBeTruthy();
+    expect(screen.getByText("Inconclusive")).toBeTruthy();
+  });
+
+  it("shows auto-detected market crash status", () => {
+    render(FallingKnifeDialog, {
+      props: {
+        ticker: "BBCA",
+        diagnostic: makeDiagnostic({ marketCrashed: true }),
+        onUpdate: vi.fn(),
+        onClose: vi.fn(),
+      },
+    });
+    const yesElements = screen.getAllByText("Yes");
+    expect(yesElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows Opportunity badge when signal is OPPORTUNITY", () => {
+    render(FallingKnifeDialog, {
+      props: {
+        ticker: "BBCA",
+        diagnostic: makeDiagnostic({ signal: "OPPORTUNITY" }),
+        onUpdate: vi.fn(),
+        onClose: vi.fn(),
+      },
+    });
+    expect(screen.getByText("Opportunity")).toBeTruthy();
+  });
+
+  it("shows Falling Knife badge when signal is FALLING_KNIFE", () => {
+    render(FallingKnifeDialog, {
+      props: {
+        ticker: "BBCA",
+        diagnostic: makeDiagnostic({ signal: "FALLING_KNIFE" }),
+        onUpdate: vi.fn(),
+        onClose: vi.fn(),
+      },
+    });
+    expect(screen.getByText("Falling Knife")).toBeTruthy();
+  });
+
+  it("calls onClose when Close button is clicked", async () => {
+    const onClose = vi.fn();
+    render(FallingKnifeDialog, {
+      props: {
+        ticker: "BBCA",
+        diagnostic: makeDiagnostic(),
+        onUpdate: vi.fn(),
+        onClose,
+      },
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Close"));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/crashplaybook/MarketStatusBanner.svelte
+++ b/frontend/src/pages/crashplaybook/MarketStatusBanner.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+import Badge from "../../lib/components/Badge.svelte";
+import { formatDecimal } from "../../lib/format";
+import type { MarketStatusResponse } from "../../lib/types";
+
+let { market }: { market: MarketStatusResponse } = $props();
+
+const conditionConfig: Record<
+  string,
+  { variant: "value" | "dividend" | "profit" | "loss" | "warning"; label: string }
+> = {
+  NORMAL: { variant: "value", label: "Normal" },
+  ELEVATED: { variant: "warning", label: "Elevated" },
+  CORRECTION: { variant: "loss", label: "Correction" },
+  CRASH: { variant: "loss", label: "Crash" },
+  RECOVERY: { variant: "profit", label: "Recovery" },
+};
+
+const config = $derived(conditionConfig[market.condition] ?? conditionConfig.NORMAL);
+</script>
+
+<div class="rounded-lg border border-border-default bg-bg-elevated p-4">
+  <div class="flex items-center justify-between">
+    <div class="flex items-center gap-3">
+      <h3 class="text-sm font-medium text-text-secondary">IHSG Market Status</h3>
+      <Badge variant={config.variant}>{config.label}</Badge>
+    </div>
+    <div class="flex items-center gap-4 text-sm">
+      <span class="font-mono font-medium text-text-primary">{formatDecimal(market.ihsgPrice)}</span>
+      <span class="font-mono {market.drawdownPct < 0 ? 'text-loss' : 'text-profit'}">
+        {formatDecimal(market.drawdownPct)}%
+      </span>
+    </div>
+  </div>
+  <div class="mt-2 flex items-center justify-between text-xs text-text-secondary">
+    <span>Peak: <span class="font-mono">{formatDecimal(market.ihsgPeak)}</span></span>
+    <span>Last fetched: {new Date(market.fetchedAt).toLocaleString("id-ID")}</span>
+  </div>
+</div>

--- a/frontend/src/pages/crashplaybook/MarketStatusBanner.test.ts
+++ b/frontend/src/pages/crashplaybook/MarketStatusBanner.test.ts
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+import type { MarketStatusResponse } from "../../lib/types";
+import MarketStatusBanner from "./MarketStatusBanner.svelte";
+
+function makeMarket(overrides: Partial<MarketStatusResponse> = {}): MarketStatusResponse {
+  return {
+    condition: "NORMAL",
+    ihsgPrice: 7200,
+    ihsgPeak: 7500,
+    drawdownPct: -4.0,
+    fetchedAt: "2026-03-05T10:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("MarketStatusBanner", () => {
+  it("renders IHSG price", () => {
+    render(MarketStatusBanner, { props: { market: makeMarket() } });
+    expect(document.body.textContent).toContain("7.200");
+  });
+
+  it("shows Normal badge for normal condition", () => {
+    render(MarketStatusBanner, { props: { market: makeMarket() } });
+    expect(screen.getByText("Normal", { exact: true })).toBeTruthy();
+  });
+
+  it("shows Crash badge for crash condition", () => {
+    render(MarketStatusBanner, {
+      props: { market: makeMarket({ condition: "CRASH", drawdownPct: -25 }) },
+    });
+    expect(screen.getByText("Crash", { exact: true })).toBeTruthy();
+  });
+
+  it("shows drawdown percentage", () => {
+    render(MarketStatusBanner, { props: { market: makeMarket() } });
+    expect(document.body.textContent).toContain("-4,00%");
+  });
+
+  it("shows peak price", () => {
+    render(MarketStatusBanner, { props: { market: makeMarket() } });
+    expect(document.body.textContent).toContain("7.500");
+  });
+});

--- a/frontend/src/pages/crashplaybook/StockPlaybookCard.svelte
+++ b/frontend/src/pages/crashplaybook/StockPlaybookCard.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+import Badge from "../../lib/components/Badge.svelte";
+import Button from "../../lib/components/Button.svelte";
+import { formatRupiah } from "../../lib/format";
+import type { CrashLevel, StockPlaybookResponse } from "../../lib/types";
+
+let {
+  stock,
+  onDiagnostic,
+}: {
+  stock: StockPlaybookResponse;
+  onDiagnostic: (ticker: string) => void;
+} = $props();
+
+const levelLabels: Record<CrashLevel, string> = {
+  NORMAL_DIP: "Normal Dip",
+  CRASH: "Crash",
+  EXTREME: "Extreme",
+};
+
+const hasActiveLevel = $derived(stock.activeLevel != null);
+</script>
+
+<div class="rounded-lg border border-border-default bg-bg-elevated p-4">
+  <div class="flex items-center justify-between">
+    <div class="flex items-center gap-3">
+      <h3 class="font-display text-base font-semibold text-text-primary">{stock.ticker}</h3>
+      {#if hasActiveLevel}
+        <Badge variant="loss">Level Hit</Badge>
+      {/if}
+    </div>
+    <span class="font-mono text-sm font-medium text-text-primary">{formatRupiah(stock.currentPrice)}</span>
+  </div>
+
+  <div class="mt-1 text-xs text-text-secondary">
+    Entry target: <span class="font-mono">{formatRupiah(stock.entryPrice)}</span>
+  </div>
+
+  <div class="mt-3 space-y-2">
+    {#each stock.levels as level}
+      {@const isActive = stock.activeLevel === level.level}
+      <div class="flex items-center justify-between rounded-md px-3 py-2 text-sm {isActive ? 'bg-negative-bg border border-negative/20' : 'bg-bg-primary'}">
+        <div class="flex items-center gap-2">
+          <span class="font-medium {isActive ? 'text-loss' : 'text-text-secondary'}">{levelLabels[level.level]}</span>
+          <span class="text-xs text-text-secondary">({level.deployPct}%)</span>
+        </div>
+        <span class="font-mono {isActive ? 'text-loss font-semibold' : 'text-text-primary'}">{formatRupiah(level.triggerPrice)}</span>
+      </div>
+    {/each}
+  </div>
+
+  {#if hasActiveLevel}
+    <div class="mt-3">
+      <Button variant="secondary" size="sm" onclick={() => onDiagnostic(stock.ticker)}>
+        Run Diagnostic
+      </Button>
+    </div>
+  {/if}
+</div>

--- a/frontend/src/pages/crashplaybook/StockPlaybookCard.test.ts
+++ b/frontend/src/pages/crashplaybook/StockPlaybookCard.test.ts
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/svelte";
+import { describe, expect, it, vi } from "vitest";
+import type { StockPlaybookResponse } from "../../lib/types";
+import StockPlaybookCard from "./StockPlaybookCard.svelte";
+
+function makeStock(overrides: Partial<StockPlaybookResponse> = {}): StockPlaybookResponse {
+  return {
+    ticker: "BBCA",
+    currentPrice: 8500,
+    entryPrice: 7500,
+    levels: [
+      { level: "NORMAL_DIP", triggerPrice: 7500, deployPct: 30 },
+      { level: "CRASH", triggerPrice: 6250, deployPct: 40 },
+      { level: "EXTREME", triggerPrice: 5250, deployPct: 30 },
+    ],
+    ...overrides,
+  };
+}
+
+describe("StockPlaybookCard", () => {
+  it("renders ticker and current price", () => {
+    render(StockPlaybookCard, { props: { stock: makeStock(), onDiagnostic: vi.fn() } });
+    expect(screen.getByText("BBCA")).toBeTruthy();
+    expect(document.body.textContent).toContain("8.500");
+  });
+
+  it("renders 3 response levels", () => {
+    render(StockPlaybookCard, { props: { stock: makeStock(), onDiagnostic: vi.fn() } });
+    expect(screen.getByText("Normal Dip")).toBeTruthy();
+    expect(screen.getByText("Crash")).toBeTruthy();
+    expect(screen.getByText("Extreme")).toBeTruthy();
+  });
+
+  it("shows Level Hit badge when active level is set", () => {
+    render(StockPlaybookCard, {
+      props: { stock: makeStock({ activeLevel: "NORMAL_DIP" }), onDiagnostic: vi.fn() },
+    });
+    expect(screen.getByText("Level Hit")).toBeTruthy();
+  });
+
+  it("shows Run Diagnostic button when active level is set", () => {
+    render(StockPlaybookCard, {
+      props: { stock: makeStock({ activeLevel: "CRASH" }), onDiagnostic: vi.fn() },
+    });
+    expect(screen.getByText("Run Diagnostic")).toBeTruthy();
+  });
+
+  it("hides Run Diagnostic button when no active level", () => {
+    render(StockPlaybookCard, { props: { stock: makeStock(), onDiagnostic: vi.fn() } });
+    expect(screen.queryByText("Run Diagnostic")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Issue
Closes #32

## Summary
- Pre-calculated crash response levels per portfolio holding (3 levels: normal dip, crash, extreme)
- Market condition detection via IHSG (^JKSE) with 5 states (Normal/Elevated/Correction/Crash/Recovery)
- Dynamic refresh interval auto-adjustment based on market condition
- Falling knife vs opportunity diagnostic (4-check system: 2 auto + 2 manual)
- Pre-committed crash capital with configurable deployment rules (must sum to 100%)
- Full test coverage: domain, usecase, infra (SQLite integration), and frontend components

## Test Plan
- [x] Linter passes (`make lint`)
- [x] All tests pass (`make test`)
- [x] Market Status Banner displays IHSG condition correctly
- [x] Stock playbook cards show 3 response levels per holding
- [x] Falling knife diagnostic auto-checks + manual toggles work
- [x] Crash capital save/load persists across restarts
- [x] Deployment settings validate sum=100%
- [x] Refresh interval adjusts when market condition changes
- [x] Recovery transitions back to Normal when drawdown improves past -5%

## Notes
- Fundamental change alerts integration deferred to v0.4
- Falling knife manual checks are session-only (not persisted) for v1
- Watchlist-level playbook deferred to future iteration