### PR TITLE
chore: move Add Holding form above table and fix CommandPalette a11y

### DIFF
--- a/frontend/src/lib/components/CommandPalette.svelte
+++ b/frontend/src/lib/components/CommandPalette.svelte
@@ -129,6 +129,7 @@ function handleKeydown(e: KeyboardEvent) {
               ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
               : 'text-text-secondary hover:bg-bg-tertiary hover:text-text-primary'}"
             onclick={() => select(item)}
+            onkeydown={(e: KeyboardEvent) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); select(item); } }}
             onmouseenter={() => { activeIndex = i; }}
           >
             <span class="flex items-center gap-3">

--- a/frontend/src/pages/portfolio/PortfolioDetail.svelte
+++ b/frontend/src/pages/portfolio/PortfolioDetail.svelte
@@ -80,6 +80,12 @@ let overallPL = $derived(calcOverallPL(detail.holdings));
   {/if}
 </div>
 
+<!-- Add Holding -->
+<div class="mb-6 rounded border border-border-default bg-bg-elevated p-4">
+  <h3 class="mb-3 text-xs font-semibold uppercase tracking-wider text-text-muted">Add Holding</h3>
+  <AddHoldingForm portfolioId={detail.portfolio.id} onAdded={onHoldingAdded} />
+</div>
+
 <!-- Holdings Table -->
 <div class="mb-6">
   <HoldingsTable holdings={detail.holdings} {onChecklist} />
@@ -119,9 +125,3 @@ let overallPL = $derived(calcOverallPL(detail.holdings));
     <DividendRankingPanel portfolioId={detail.portfolio.id} />
   </div>
 {/if}
-
-<!-- Add Holding -->
-<div class="rounded border border-border-default bg-bg-elevated p-4">
-  <h3 class="mb-3 text-xs font-semibold uppercase tracking-wider text-text-muted">Add Holding</h3>
-  <AddHoldingForm portfolioId={detail.portfolio.id} onAdded={onHoldingAdded} />
-</div>


### PR DESCRIPTION
## Issue
N/A

## Summary
- Move the "Add Holding" form from the bottom of PortfolioDetail to between the Summary Bar and Holdings Table for immediate access
- Fix CommandPalette a11y warning by adding `onkeydown` handler on `<li role="option">` elements (Enter/Space to select)

## Test Plan
- [x] Linter passes (`make lint`) — 0 issues
- [x] Frontend unit tests pass (`make test-frontend`) — 386/386
- [x] Visual check — Add Holding form appears between summary bar and holdings table

## Notes
Layout order is now: Header → Summary Bar → Add Holding → Holdings Table → Trailing Stops / Dividend Metrics.