### PR TITLE
fix: format last refresh date in settings page

### DIFF
--- a/frontend/src/pages/settings/SettingsPage.svelte
+++ b/frontend/src/pages/settings/SettingsPage.svelte
@@ -15,6 +15,7 @@ import Button from "../../lib/components/Button.svelte";
 import Select from "../../lib/components/Select.svelte";
 import ThemeToggle from "../../lib/components/ThemeToggle.svelte";
 import Tooltip from "../../lib/components/Tooltip.svelte";
+import { formatRelativeTime } from "../../lib/format";
 import { sync } from "../../lib/stores/sync.svelte";
 import { theme } from "../../lib/stores/theme.svelte";
 import { toastStore } from "../../lib/stores/toast.svelte";
@@ -150,7 +151,7 @@ function openRelease(url: string) {
 
         {#if lastRefreshedAt}
           <p class="text-xs text-text-tertiary">
-            {t("settings.lastRefreshed")} <span class="font-mono">{lastRefreshedAt}</span>
+            {t("settings.lastRefreshed")} <span class="font-mono">{formatRelativeTime(lastRefreshedAt)}</span>
           </p>
         {/if}
 

--- a/frontend/src/pages/settings/SettingsPage.test.ts
+++ b/frontend/src/pages/settings/SettingsPage.test.ts
@@ -56,6 +56,10 @@ vi.mock("../../../wailsjs/runtime/runtime", () => ({
   EventsOn: vi.fn(),
 }));
 
+vi.mock("../../lib/format", () => ({
+  formatRelativeTime: (iso: string) => (iso ? "5m ago" : "Not synced yet"),
+}));
+
 // Mock theme store to avoid localStorage initialization issues in ThemeToggle.
 vi.mock("../../lib/stores/theme.svelte", () => ({
   theme: {
@@ -119,6 +123,7 @@ describe("SettingsPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("1.2.0")).toBeInTheDocument();
+      expect(screen.getByText("5m ago")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- Reuse existing `formatRelativeTime` to display the last refresh date in Settings as a human-readable relative time (e.g., "5m ago") instead of a raw ISO string

## Test plan
- [x] `make test-frontend` — all 475 tests pass including updated SettingsPage test
- [x] `make dev` — open Settings, verify last refresh shows relative time