### PR TITLE
refactor: replace inline empty states with shared EmptyState component

### DIFF
--- a/frontend/src/pages/brokerage/BrokeragePage.svelte
+++ b/frontend/src/pages/brokerage/BrokeragePage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Pencil, Plus, Trash2 } from "lucide-svelte";
+import { Landmark, Pencil, Plus, Trash2 } from "lucide-svelte";
 import {
   DeleteBrokerageAccount,
   ListBrokerageAccounts,
@@ -10,6 +10,7 @@ import BrokerageAccountForm from "../../components/BrokerageAccountForm.svelte";
 import { t } from "../../i18n";
 import Button from "../../lib/components/Button.svelte";
 import ConfirmDialog from "../../lib/components/ConfirmDialog.svelte";
+import EmptyState from "../../lib/components/EmptyState.svelte";
 import LoadingState from "../../lib/components/LoadingState.svelte";
 import { EventBrokerFeesSynced } from "../../lib/events";
 import { formatPercent } from "../../lib/format";
@@ -137,16 +138,14 @@ $effect(() => {
     </div>
   {:else if state === "list"}
     {#if accounts.length === 0}
-      <div class="rounded border border-border-default bg-bg-elevated px-6 py-12 text-center">
-        <p class="mb-2 text-text-primary font-medium">{t("brokerage.noAccounts")}</p>
-        <p class="mb-6 text-sm text-text-secondary">
-          {t("brokerage.noAccountsDesc")}
-        </p>
-        <Button onclick={startCreate}>
-          <Plus size={16} strokeWidth={2} />
-          {t("brokerage.addAccount")}
-        </Button>
-      </div>
+      <EmptyState icon={Landmark} title={t("brokerage.noAccounts")} description={t("brokerage.noAccountsDesc")}>
+        {#snippet action()}
+          <Button onclick={startCreate}>
+            <Plus size={16} strokeWidth={2} />
+            {t("brokerage.addAccount")}
+          </Button>
+        {/snippet}
+      </EmptyState>
     {:else}
       <div class="grid gap-4">
         {#each accounts as acct}

--- a/frontend/src/pages/crashplaybook/CrashPlaybookPage.svelte
+++ b/frontend/src/pages/crashplaybook/CrashPlaybookPage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { PackageOpen, ShieldAlert } from "lucide-svelte";
 import {
   GetCrashCapital,
   GetDeploymentPlan,
@@ -11,6 +12,7 @@ import {
 } from "../../../wailsjs/go/backend/App";
 import { t } from "../../i18n";
 import Button from "../../lib/components/Button.svelte";
+import EmptyState from "../../lib/components/EmptyState.svelte";
 import LoadingState from "../../lib/components/LoadingState.svelte";
 import Select from "../../lib/components/Select.svelte";
 import Tooltip from "../../lib/components/Tooltip.svelte";
@@ -161,9 +163,7 @@ $effect(() => {
       </div>
     </div>
   {:else if state === "empty"}
-    <div class="mt-6 text-center text-sm text-text-secondary">
-      {t("crashPlaybook.noPortfolios")}
-    </div>
+    <EmptyState icon={ShieldAlert} title={t("crashPlaybook.noPortfolios")} />
   {:else if state === "ready" && playbook}
     <div class="mt-4">
       <Select value={selectedPortfolioId} onchange={handlePortfolioChange} aria-label="Select portfolio">
@@ -190,9 +190,7 @@ $effect(() => {
         {/each}
       </div>
     {:else}
-      <div class="mt-6 text-center text-sm text-text-secondary">
-        {t("crashPlaybook.noHoldings")}
-      </div>
+      <EmptyState icon={PackageOpen} title={t("crashPlaybook.noHoldings")} />
     {/if}
 
     {#if capital}

--- a/frontend/src/pages/portfolio/DividendRankingPanel.svelte
+++ b/frontend/src/pages/portfolio/DividendRankingPanel.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-import { TrendingUp } from "lucide-svelte";
+import { TrendingUp, Trophy } from "lucide-svelte";
 import { GetDividendRanking } from "../../../wailsjs/go/backend/App";
 import { t } from "../../i18n";
+import EmptyState from "../../lib/components/EmptyState.svelte";
 import LoadingState from "../../lib/components/LoadingState.svelte";
 import { getDividendIndicatorDisplay } from "../../lib/dividend-indicator";
 import { formatDecimal, formatPercent } from "../../lib/format";
@@ -46,7 +47,7 @@ loadRanking();
       {error}
     </div>
   {:else if items.length === 0}
-    <p class="py-4 text-center text-sm text-text-muted">{t("dividendRanking.noStocks")}</p>
+    <EmptyState icon={Trophy} title={t("dividendRanking.noStocks")} />
   {:else}
     <div class="overflow-x-auto rounded border border-border-default">
       <table class="w-full text-sm" aria-label="Dividend Ranking">

--- a/frontend/src/pages/screener/ScreenerPage.svelte
+++ b/frontend/src/pages/screener/ScreenerPage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { CheckCircle2, XCircle } from "lucide-svelte";
+import { CheckCircle2, SearchX, SlidersHorizontal, XCircle } from "lucide-svelte";
 import {
   ListScreenerIndices,
   ListScreenerSectors,
@@ -7,6 +7,7 @@ import {
 } from "../../../wailsjs/go/backend/App";
 import { t } from "../../i18n";
 import Badge from "../../lib/components/Badge.svelte";
+import EmptyState from "../../lib/components/EmptyState.svelte";
 import LoadingState from "../../lib/components/LoadingState.svelte";
 import SortableHeader from "../../lib/components/SortableHeader.svelte";
 import Tooltip from "../../lib/components/Tooltip.svelte";
@@ -151,14 +152,7 @@ loadReferenceData();
 
   <!-- Content -->
   {#if state === "initial"}
-    <div class="flex flex-1 items-center justify-center py-24 text-center">
-      <div>
-        <p class="mb-1 font-medium text-text-primary">{t("screener.configurePrompt")}</p>
-        <p class="text-sm text-text-secondary">
-          {t("screener.configureDescription")}
-        </p>
-      </div>
-    </div>
+    <EmptyState icon={SlidersHorizontal} title={t("screener.configurePrompt")} description={t("screener.configureDescription")} />
   {:else if state === "loading"}
     <LoadingState message={t("screener.screening")} class="flex-1 py-16" />
   {:else if state === "error"}
@@ -187,12 +181,7 @@ loadReferenceData();
     </div>
 
     {#if results.length === 0}
-      <div class="flex flex-1 items-center justify-center py-16 text-center">
-        <div>
-          <p class="mb-1 font-medium text-text-primary">{t("screener.noResults")}</p>
-          <p class="text-sm text-text-secondary">{t("screener.noResultsHint")}</p>
-        </div>
-      </div>
+      <EmptyState icon={SearchX} title={t("screener.noResults")} description={t("screener.noResultsHint")} />
     {:else}
       <!-- Results Table -->
       <div class="flex-1 overflow-x-auto">

--- a/frontend/src/pages/watchlist/WatchlistPage.svelte
+++ b/frontend/src/pages/watchlist/WatchlistPage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { LoaderCircle, Plus, Trash2, X } from "lucide-svelte";
+import { List, LoaderCircle, PackageOpen, Plus, Trash2, X } from "lucide-svelte";
 import {
   GetPresetItems,
   GetWatchlistItems,
@@ -10,6 +10,7 @@ import {
 } from "../../../wailsjs/go/backend/App";
 import { t } from "../../i18n";
 import Badge from "../../lib/components/Badge.svelte";
+import EmptyState from "../../lib/components/EmptyState.svelte";
 import LoadingState from "../../lib/components/LoadingState.svelte";
 import Tooltip from "../../lib/components/Tooltip.svelte";
 import { formatPercent, formatRupiah } from "../../lib/format";
@@ -262,15 +263,7 @@ load();
   <!-- Right Panel -->
   <div class="flex flex-1 flex-col overflow-y-auto bg-bg-primary">
     {#if activeType === null}
-      <!-- Empty state: nothing selected -->
-      <div class="flex flex-1 items-center justify-center py-24 text-center">
-        <div>
-          <p class="mb-1 font-medium text-text-primary">{t("watchlist.selectWatchlist")}</p>
-          <p class="text-sm text-text-secondary">
-            {t("watchlist.selectWatchlistDesc")}
-          </p>
-        </div>
-      </div>
+      <EmptyState icon={List} title={t("watchlist.selectWatchlist")} description={t("watchlist.selectWatchlistDesc")} />
     {:else}
       <!-- Header -->
       <div class="border-b border-border-default px-6 py-4">
@@ -324,18 +317,11 @@ load();
           </div>
         {/if}
         {#if filteredItems.length === 0}
-          <div class="flex flex-1 items-center justify-center py-16 text-center">
-            <div>
-              <p class="mb-1 font-medium text-text-primary">{t("watchlist.noItems")}</p>
-              <p class="text-sm text-text-secondary">
-                {#if activeType === "watchlist"}
-                  {t("watchlist.addTickerHint")}
-                {:else}
-                  {t("watchlist.indexEmptyHint")}
-                {/if}
-              </p>
-            </div>
-          </div>
+          <EmptyState
+            icon={PackageOpen}
+            title={t("watchlist.noItems")}
+            description={activeType === "watchlist" ? t("watchlist.addTickerHint") : t("watchlist.indexEmptyHint")}
+          />
         {:else}
           <!-- Items Table -->
           <div class="overflow-x-auto">


### PR DESCRIPTION
## Issue
Closes #96

## Summary
- Replace 8 inline empty-state markup patterns across 5 files with the shared `EmptyState` component
- Adds contextual icons (SlidersHorizontal, SearchX, List, PackageOpen, Landmark, ShieldAlert, Trophy) for each empty state
- Net reduction of 27 lines; consistent styling and behavior across all empty states

## Test Plan
- [x] Linter passes (`make lint`) — 0 issues
- [x] Formatter passes (`make fmt`) — no fixes
- [x] All tests pass (`make test`) — 535 passed
- [x] No remaining inline empty-state patterns in target files (grep verified)
- [x] EmptyState component unit tests pass (4 tests)
- [x] Visual check: ScreenerPage initial state — icon + title + description render correctly
- [x] Visual check: ScreenerPage results path — table renders, no regressions
- [x] Visual check: WatchlistPage nothing-selected — List icon + title + description render correctly
- [x] Visual check: BrokeragePage — page renders correctly (has existing account, no regression)
- [x] Visual check: CrashPlaybookPage — page renders correctly with stock cards and capital panel
- [x] Visual check: DividendRankingPanel — DCA Ranking table renders correctly in Dividend Portfolio

## Notes
- The BrokeragePage previously wrapped its empty state in a card (`rounded border bg-bg-elevated`). This wrapper is removed to match how other pages use EmptyState (plain centered layout, consistent with DashboardPage, AlertsPage, etc.)
- Two similar patterns in payday pages identified as follow-up: #111
- Some empty states (Brokerage no accounts, CrashPlaybook no portfolios/holdings, Screener no results, Watchlist filtered empty, DividendRanking no stocks) require specific data conditions to trigger — the component wiring was verified via code review and the EmptyState unit tests cover all rendering paths (title, description, icon, action snippet)