### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/wails.json
+++ b/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "Lugas Septiawan",
     "productName": "Panen",
-    "productVersion": "0.1.0",
+    "productVersion": "1.0.0",
     "copyright": "Copyright 2026 Lugas Septiawan",
     "comments": "Desktop decision engine for Indonesian Stock Exchange (IDX) investors"
   }


### PR DESCRIPTION
## Summary
- Bump `wails.json` `productVersion` from `0.1.0` to `1.0.0` for the v1.0 release

## Notes
After merge, run `scripts/release.sh 1.0.0` to create the tag and trigger the release workflow.