### PR TITLE
fix: use ubuntu-22.04 for Linux release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           - os: macos-latest
             platform: darwin/universal
             archive_name: panen-darwin-universal.zip
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             platform: linux/amd64
             archive_name: panen-linux-amd64.tar.gz
           - os: windows-latest
@@ -40,7 +40,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
 
       - name: Install frontend dependencies
         run: |


### PR DESCRIPTION
## Summary
- Use `ubuntu-22.04` for Linux build in release workflow — Wails v2 requires `webkit2gtk-4.0` which is not available on Ubuntu 24.04 (`ubuntu-latest`)
- Revert `libwebkit2gtk-4.1-dev` back to `libwebkit2gtk-4.0-dev` to match Ubuntu 22.04

## Issue
Fixes release build failure: `Package 'webkit2gtk-4.0', required by 'virtual:world', not found`

## Test plan
- [ ] Trigger release workflow via `workflow_dispatch` or tag push to verify Linux build succeeds