### PR TITLE
fix: capitalize macOS app bundle name to Panen.app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           cd build/bin
-          zip -r ../../${{ matrix.archive_name }} panen.app/
+          zip -r ../../${{ matrix.archive_name }} Panen.app/
 
       - name: Package (Linux)
         if: runner.os == 'Linux'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,7 @@ make release-check VERSION=0.2.0  # Local validation only (no tag/push)
 
 | Platform | Archive | Contents |
 |----------|---------|----------|
-| macOS | `panen-darwin-universal.zip` | `panen.app/` bundle |
+| macOS | `panen-darwin-universal.zip` | `Panen.app/` bundle |
 | Linux | `panen-linux-amd64.tar.gz` | Binary + `.desktop` + icon |
 | Windows | `panen-windows-amd64.zip` | `panen.exe` |
 
@@ -239,5 +239,5 @@ PANEN_VERSION=v0.2.0 curl -fsSL https://raw.githubusercontent.com/lugassawan/pan
 ```
 
 Install locations (no sudo required):
-- **macOS**: `~/Applications/panen.app`
+- **macOS**: `~/Applications/Panen.app`
 - **Linux**: `~/.local/bin/panen` + `.desktop` + icon

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ PANEN_VERSION=v1.0.0 curl -fsSL https://raw.githubusercontent.com/lugassawan/pan
 
 | Platform | Location |
 |----------|----------|
-| macOS | `~/Applications/panen.app` |
+| macOS | `~/Applications/Panen.app` |
 | Linux | `~/.local/bin/panen` + `.desktop` + icon |
 
 ### Windows

--- a/backend/infra/updater/installer_darwin.go
+++ b/backend/infra/updater/installer_darwin.go
@@ -22,6 +22,8 @@ func (i *darwinInstaller) ArchiveName() string {
 }
 
 // InstallPath walks up from the current executable to find the .app bundle root.
+// It returns the canonical path with "Panen.app" regardless of the actual folder name,
+// so that upgrades from the old "panen.app" name produce the new name.
 func (i *darwinInstaller) InstallPath() (string, error) {
 	exe, err := os.Executable()
 	if err != nil {
@@ -32,7 +34,7 @@ func (i *darwinInstaller) InstallPath() (string, error) {
 		return "", fmt.Errorf("eval symlinks: %w", err)
 	}
 
-	// Walk up to find .app bundle (e.g. /Applications/panen.app/Contents/MacOS/panen)
+	// Walk up to find .app bundle (e.g. /Applications/Panen.app/Contents/MacOS/panen)
 	dir := exe
 	for {
 		dir = filepath.Dir(dir)
@@ -40,7 +42,7 @@ func (i *darwinInstaller) InstallPath() (string, error) {
 			break
 		}
 		if strings.HasSuffix(dir, ".app") {
-			return dir, nil
+			return filepath.Join(filepath.Dir(dir), "Panen.app"), nil
 		}
 	}
 	return "", fmt.Errorf("no .app bundle found for %s", exe)
@@ -53,7 +55,10 @@ func (i *darwinInstaller) Install(
 	backupPath := installPath + ".backup"
 
 	if err := os.Rename(installPath, backupPath); err != nil {
-		return fmt.Errorf("backup current app: %w", err)
+		legacyPath := filepath.Join(filepath.Dir(installPath), "panen.app")
+		if renameErr := os.Rename(legacyPath, backupPath); renameErr != nil {
+			return fmt.Errorf("backup current app: %w", err)
+		}
 	}
 
 	// Find the .app in the extracted directory

--- a/backend/usecase/selfupdate_test.go
+++ b/backend/usecase/selfupdate_test.go
@@ -139,7 +139,7 @@ func TestSelfUpdateHappyPath(t *testing.T) {
 	extractor := &mockExtractor{}
 	installer := &mockInstaller{
 		archiveName: "panen-test.zip",
-		installPath: filepath.Join(tmpDir, "panen.app"),
+		installPath: filepath.Join(tmpDir, "Panen.app"),
 	}
 	emitter := newMockEventEmitter()
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -117,13 +117,14 @@ install_darwin() {
   INSTALL_DIR="${HOME}/Applications"
   mkdir -p "$INSTALL_DIR"
 
-  log "Extracting to ${INSTALL_DIR}/panen.app..."
-  # Remove existing installation
+  log "Extracting to ${INSTALL_DIR}/Panen.app..."
+  # Remove old lowercase version (pre-rename) and current installation
   rm -rf "${INSTALL_DIR}/panen.app"
+  rm -rf "${INSTALL_DIR}/Panen.app"
   unzip -q "${WORK_DIR}/${ARCHIVE}" -d "$INSTALL_DIR"
 
   log ""
-  log "Panen has been installed to ${INSTALL_DIR}/panen.app"
+  log "Panen has been installed to ${INSTALL_DIR}/Panen.app"
   log "You can launch it from ~/Applications or Spotlight."
 }
 

--- a/wails.json
+++ b/wails.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://wails.io/schemas/config.v2.json",
-  "name": "panen",
+  "name": "Panen",
   "outputfilename": "panen",
   "frontend:install": "pnpm install",
   "frontend:build": "pnpm run build",


### PR DESCRIPTION
## Issue
N/A

## Summary
- Change `wails.json` `name` from `"panen"` to `"Panen"` so the macOS `.app` bundle is `Panen.app` (displays correctly in Finder, Dock, and Spotlight)
- Update release workflow, install script, and self-updater to use `Panen.app`
- Add legacy `panen.app` fallback in self-updater for users upgrading from old lowercase bundle on case-sensitive filesystems
- Update documentation references in CLAUDE.md and README.md

## Test Plan
- [x] Linter passes (`make lint`)
- [x] Go tests pass (`make test-go`)
- [ ] `make build` produces `build/bin/Panen.app` (not `panen.app`)
- [ ] Built app shows "Panen" in menu bar, Dock, and Finder

## Notes
- `outputfilename` stays lowercase `"panen"` — this is the binary inside `Contents/MacOS/`, which is conventional
- Linux/Windows paths are unchanged (lowercase binary is standard)
- On case-insensitive APFS (macOS default), `os.Rename("Panen.app", ...)` already matches `panen.app`; the legacy fallback handles case-sensitive APFS