### PR TITLE
chore: copy .claude directory to rimba worktrees

### DIFF
--- a/.rimba/settings.toml
+++ b/.rimba/settings.toml
@@ -1,3 +1,5 @@
+copy_files = ['.claude']
+
 [deps]
 # Disabled: make init already handles pnpm install; auto-detect would duplicate it.
 auto_detect = false


### PR DESCRIPTION
## Issue
N/A

## Summary
- Add `copy_files = ['.claude']` to rimba settings so worktrees automatically get the `.claude` directory copied over, preserving Claude Code project configuration (memory, settings) in worktree environments.

## Test Plan
- [x] Linter passes (`make lint`)
- [x] Create a worktree with `rimba add test-wt` and verify `.claude` directory is present

## Notes
None.