### PR TITLE
chore: improve make init for worktree setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,11 +81,17 @@ frontend-install:
 
 init:
 	cd frontend && pnpm install
+	mkdir -p frontend/dist
+	wails generate module
+	$(MAKE) custom-gcl
 	git config core.hooksPath .githooks
 
 setup:
 	go install github.com/wailsapp/wails/v2/cmd/wails@latest
 	cd frontend && pnpm install
+	mkdir -p frontend/dist
+	wails generate module
+	$(MAKE) custom-gcl
 	git config core.hooksPath .githooks
 
 release-check:


### PR DESCRIPTION
## Issue

N/A

## Summary

- Add `mkdir -p frontend/dist` to `make init` and `make setup` so `go:embed all:frontend/dist` works in fresh worktrees
- Add `wails generate module` to generate `frontend/wailsjs/` bindings (gitignored, needed for tests and dev)
- Add `$(MAKE) custom-gcl` to pre-build the golangci-lint binary so first commit is fast

### Context

When `rimba add` creates a worktree, it runs `make init` via `post_create`. Previously, worktrees were missing:
- `frontend/dist/` — caused `go:embed` errors when running Go tests or lint
- `frontend/wailsjs/` — caused `ERR_MODULE_NOT_FOUND` in frontend tests
- `custom-gcl` binary — first commit had to build it from scratch

## Test Plan

- [x] Linter passes (`make lint`)
- [x] Go tests pass (`make test-go`)
- [x] Frontend tests pass — 567/567 (`make test-frontend`)
- [ ] `rimba add` creates a fully functional worktree (Go commit + frontend tests work without manual setup)

## Notes

- Testing whether this also resolves the worktree index corruption during Go commits (previously caused by `golangci-lint custom` building from scratch during pre-commit hook with `GIT_INDEX_FILE` set)