### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/build/windows/panen.exe.manifest
+++ b/build/windows/panen.exe.manifest
@@ -3,7 +3,7 @@
   <assemblyIdentity
     type="win32"
     name="com.lugasseptiawan.panen"
-    version="1.0.1.0"
+    version="1.0.2.0"
     processorArchitecture="*"
   />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/wails.json
+++ b/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "Lugas Septiawan",
     "productName": "Panen",
-    "productVersion": "1.0.1",
+    "productVersion": "1.0.2",
     "copyright": "Copyright 2026 Lugas Septiawan",
     "comments": "Desktop decision engine for Indonesian Stock Exchange (IDX) investors"
   }


### PR DESCRIPTION
## Issue
N/A

## Summary
- Bump version to 1.0.2 in `wails.json` and Windows manifest

## Test Plan
- [x] `make release-check VERSION=1.0.2` passes
- [x] `wails.json` shows `productVersion: \"1.0.2\"`
- [x] `build/windows/panen.exe.manifest` shows `version=\"1.0.2.0\"`

## Notes
Created by `scripts/bump-version.sh`.