### PR TITLE
fix: remove broken Search button from sidebar

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -40,7 +40,7 @@ function navigateTo(page: Page) {
   <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:bg-bg-elevated focus:text-text-primary focus:px-4 focus:py-2 focus:rounded-lg focus:shadow-lg focus:ring-2 focus:ring-accent">
     {t("a11y.skipToContent")}
   </a>
-  <Sidebar {currentPage} onNavigate={navigateTo} onToggleCommandPalette={() => commandPalette.toggle()} />
+  <Sidebar {currentPage} onNavigate={navigateTo} />
 
   <main id="main-content" tabindex="-1" class="flex-1 overflow-y-auto">
     {#if currentPage === "dashboard"}

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -18,7 +18,6 @@ vi.mock("./i18n", () => ({
       "nav.alerts": "Alerts",
       "nav.brokerage": "Brokerage",
       "nav.settings": "Settings",
-      "nav.search": "Search",
       "nav.searchPages": "Search pages...",
       "nav.noResults": "No results found",
       "comparison.title": "Stock Comparison",
@@ -176,11 +175,11 @@ vi.mock("./lib/stores/theme.svelte", () => ({
 }));
 
 describe("App navigation", () => {
-  it("renders sidebar with 13 nav items including search hint", () => {
+  it("renders sidebar with 12 nav items", () => {
     render(App);
     const nav = screen.getByRole("navigation", { name: /main/i });
     const buttons = within(nav).getAllByRole("button");
-    expect(buttons).toHaveLength(13);
+    expect(buttons).toHaveLength(12);
     expect(buttons[0]).toHaveTextContent("Dashboard");
     expect(buttons[1]).toHaveTextContent("Stock Lookup");
     expect(buttons[2]).toHaveTextContent("Watchlist");
@@ -192,8 +191,7 @@ describe("App navigation", () => {
     expect(buttons[8]).toHaveTextContent("Transactions");
     expect(buttons[9]).toHaveTextContent("Alerts");
     expect(buttons[10]).toHaveTextContent("Brokerage");
-    expect(buttons[11]).toHaveTextContent("Search");
-    expect(buttons[12]).toHaveTextContent("Settings");
+    expect(buttons[11]).toHaveTextContent("Settings");
   });
 
   it("starts on Dashboard page by default", async () => {

--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -20,12 +20,7 @@ import { alerts } from "../lib/stores/alerts.svelte";
 import { mode } from "../lib/stores/mode.svelte";
 import type { Page } from "../lib/types";
 
-let {
-  currentPage,
-  onNavigate,
-  onToggleCommandPalette,
-}: { currentPage: Page; onNavigate: (page: Page) => void; onToggleCommandPalette?: () => void } =
-  $props();
+let { currentPage, onNavigate }: { currentPage: Page; onNavigate: (page: Page) => void } = $props();
 
 type NavGroup = "overview" | "research" | "portfolio" | "account";
 
@@ -99,18 +94,6 @@ $effect(() => {
     <li class="mt-auto border-t border-border-default">
       <SyncIndicator />
     </li>
-    {#if onToggleCommandPalette}
-      <li>
-        <button
-          onclick={onToggleCommandPalette}
-          class="flex w-full items-center gap-3 px-4 py-2 text-xs text-text-tertiary transition-fast hover:text-text-secondary focus-ring rounded-md"
-        >
-          <Search size={16} aria-hidden="true" />
-          <span>{t("nav.search")}</span>
-          <kbd class="ml-auto rounded border border-border-default bg-bg-tertiary px-1.5 py-0.5 font-mono text-[10px]">⌘K</kbd>
-        </button>
-      </li>
-    {/if}
     <li>
       <button
         onclick={() => onNavigate("settings")}

--- a/frontend/src/components/Sidebar.test.ts
+++ b/frontend/src/components/Sidebar.test.ts
@@ -17,7 +17,6 @@ vi.mock("../i18n", () => ({
       "nav.brokerage": "Brokerage",
       "nav.comparison": "Compare",
       "nav.settings": "Settings",
-      "nav.searchPages": "Search pages...",
       "nav.noResults": "No results found",
       "nav.group.overview": "Overview",
       "nav.group.research": "Research",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -68,7 +68,6 @@
     "brokerage": "Brokerage",
     "comparison": "Compare",
     "settings": "Settings",
-    "search": "Search",
     "searchPages": "Search pages...",
     "noResults": "No results found",
     "group": {

--- a/frontend/src/i18n/id.json
+++ b/frontend/src/i18n/id.json
@@ -68,7 +68,6 @@
     "brokerage": "Sekuritas",
     "comparison": "Bandingkan",
     "settings": "Pengaturan",
-    "search": "Cari",
     "searchPages": "Cari halaman...",
     "noResults": "Tidak ada hasil",
     "group": {


### PR DESCRIPTION
## Issue

N/A

## Summary

- Remove the Search button from the sidebar that was added in PR #139 — it had mismatched styling (`text-xs py-2` vs nav items' `text-sm py-3`) and duplicates functionality already available via Cmd+K and "/" keyboard shortcuts
- Clean up `onToggleCommandPalette` prop from `Sidebar` component and `App` usage
- Remove unused `nav.search` i18n key from `en.json` and `id.json`
- Update tests to reflect the removal (button count 13→12, remove search-related assertions and mock keys)

## Test Plan

- [x] `make lint` passes — 0 issues
- [x] `make test-frontend` passes — 84 files, 567 tests
- [x] `make dev` — sidebar no longer shows Search button above Settings
- [x] Cmd+K still opens command palette
- [x] "/" still opens command palette
- [x] Settings button still works

## Notes

The `Search` icon import in `Sidebar.svelte` is retained — it's used by the "Stock Lookup" nav item, not the removed search button.