### PR TITLE
chore: configure Playwright MCP screenshot output directory

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "playwright": {
+    "command": "npx",
+    "args": [
+      "@playwright/mcp@latest",
+      "--output-dir",
+      ".playwright-mcp"
+    ]
+  }
+}


### PR DESCRIPTION
## Issue
N/A

## Summary
- Add project-level `.mcp.json` to configure Playwright MCP with `--output-dir .playwright-mcp`, consolidating all MCP artifacts (screenshots, console logs) into one gitignored directory

## Test Plan
- [ ] Start a new Claude Code session and verify Playwright MCP server picks up the config
- [ ] Take a screenshot with `mcp__plugin_playwright_playwright__browser_take_screenshot` and confirm it lands in `.playwright-mcp/`

## Notes
The `.playwright-mcp/` directory is already in `.gitignore`.