### PR TITLE
feat: add financial statement providers (FMP + SectorsApp)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -88,6 +88,8 @@ linters:
       - path: (_test\.go|testutil/)
         linters: [gosec]
       - path: _test\.go
+        linters: [dupl]
+      - path: _test\.go
         linters: [goconst]
       - path: _test\.go
         linters: [gocognit]

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "playwright": {
+    "command": "npx",
+    "args": [
+      "@playwright/mcp@latest",
+      "--output-dir",
+      ".playwright-mcp"
+    ]
+  }
+}

--- a/backend/app.go
+++ b/backend/app.go
@@ -13,11 +13,14 @@ import (
 	"github.com/lugassawan/panen/backend/infra/backup"
 	brokerConfigLoader "github.com/lugassawan/panen/backend/infra/brokerconfig"
 	"github.com/lugassawan/panen/backend/infra/database"
+	"github.com/lugassawan/panen/backend/infra/fmp"
+	"github.com/lugassawan/panen/backend/infra/fsprovider"
 	"github.com/lugassawan/panen/backend/infra/github"
 	"github.com/lugassawan/panen/backend/infra/liveconfig"
 	"github.com/lugassawan/panen/backend/infra/platform"
 	infraProvider "github.com/lugassawan/panen/backend/infra/provider"
 	"github.com/lugassawan/panen/backend/infra/scraper"
+	"github.com/lugassawan/panen/backend/infra/sectorsapp"
 	"github.com/lugassawan/panen/backend/infra/updater"
 	"github.com/lugassawan/panen/backend/infra/watchlistconfig"
 	"github.com/lugassawan/panen/backend/presenter"
@@ -50,6 +53,7 @@ type App struct {
 	*presenter.TransactionHandler
 	*presenter.DashboardHandler
 	*presenter.ProviderHandler
+	*presenter.SettingsHandler
 	db        *database.DB
 	backup    *backup.BackupService
 	dbPath    string
@@ -81,6 +85,9 @@ type repos struct {
 	cashFlow        *database.CashFlowRepo
 	txnHistory      *database.TransactionHistoryRepo
 	crashCapital    *database.CrashCapitalRepo
+	incomeStmt      *database.IncomeStatementRepo
+	balanceSheet    *database.BalanceSheetRepo
+	cashFlowStmt    *database.CashFlowStatementRepo
 }
 
 // services groups all application service instances.
@@ -102,6 +109,7 @@ type services struct {
 	crashPlaybook *usecase.CrashPlaybookService
 	update        *usecase.UpdateService
 	selfUpdate    *usecase.SelfUpdateService
+	financials    *usecase.FinancialStatementsService
 }
 
 // NewApp creates all handlers upfront so embedded pointers are never nil.
@@ -130,6 +138,7 @@ func NewApp() *App {
 		TransactionHandler:      &presenter.TransactionHandler{},
 		DashboardHandler:        &presenter.DashboardHandler{},
 		ProviderHandler:         &presenter.ProviderHandler{},
+		SettingsHandler:         &presenter.SettingsHandler{},
 		backup:                  backup.NewBackupService(),
 	}
 }
@@ -172,6 +181,8 @@ func (a *App) Startup(ctx context.Context) {
 	registry.Register(scraper.NewYahoo(), 1)
 	registry.Register(infraProvider.NewIDXProvider(), 2)
 
+	fsRegistry := a.initFSProviders(ctx, r.settings)
+
 	sectorRegistry := watchlistconfig.NewSectorRegistry()
 	liveDeps := liveconfig.Deps{
 		Settings: r.settings,
@@ -185,7 +196,7 @@ func (a *App) Startup(ctx context.Context) {
 	indexResult := indexLoader.Load(ctx)
 	swappableIndexReg := watchlistconfig.NewSwappableIndexRegistry(indexResult.Data)
 
-	svc := a.initServices(r, registry, wailsEmitter, sectorRegistry, swappableIndexReg)
+	svc := a.initServices(r, registry, fsRegistry, wailsEmitter, sectorRegistry, swappableIndexReg)
 
 	a.bindHandlers(ctx, svc, r, profileID, sectorRegistry, registry, wailsEmitter)
 
@@ -292,6 +303,9 @@ func (a *App) initRepos(conn *sql.DB) repos {
 		cashFlow:        database.NewCashFlowRepo(conn),
 		txnHistory:      database.NewTransactionHistoryRepo(conn),
 		crashCapital:    database.NewCrashCapitalRepo(conn),
+		incomeStmt:      database.NewIncomeStatementRepo(conn),
+		balanceSheet:    database.NewBalanceSheetRepo(conn),
+		cashFlowStmt:    database.NewCashFlowStatementRepo(conn),
 	}
 }
 
@@ -310,6 +324,7 @@ func (a *App) initDebugLogging(ctx context.Context, settingsRepo *database.Setti
 func (a *App) initServices(
 	r repos,
 	registry *infraProvider.Registry,
+	fsRegistry *fsprovider.Registry,
 	emitter *presenter.WailsEmitter,
 	sectorRegistry *watchlistconfig.SectorRegistry,
 	indexReg *watchlistconfig.SwappableIndexRegistry,
@@ -359,6 +374,10 @@ func (a *App) initServices(
 		installer, emitter, Version(),
 	)
 
+	financialsSvc := usecase.NewFinancialStatementsService(
+		r.incomeStmt, r.balanceSheet, r.cashFlowStmt, fsRegistry,
+	)
+
 	return services{
 		stocks:        stocks,
 		portfolios:    portfolios,
@@ -377,6 +396,7 @@ func (a *App) initServices(
 		crashPlaybook: crashPlaybook,
 		update:        updateSvc,
 		selfUpdate:    selfUpdateSvc,
+		financials:    financialsSvc,
 	}
 }
 
@@ -408,6 +428,30 @@ func (a *App) bindHandlers(
 	a.UpdateHandler.Bind(ctx, svc.update, svc.selfUpdate, r.settings, emitter)
 	a.LogHandler.Bind(ctx, r.settings, a.logDir)
 	a.ProviderHandler.Bind(ctx, registry)
+	a.SettingsHandler.Bind(ctx, r.settings)
+}
+
+// initFSProviders reads API keys from settings and creates financial statement providers.
+func (a *App) initFSProviders(ctx context.Context, settings *database.SettingsRepo) *fsprovider.Registry {
+	fsReg := fsprovider.NewRegistry()
+
+	fmpKey, err := settings.GetSetting(ctx, "fmp_api_key")
+	if err != nil {
+		applog.Warn("read FMP API key", err, nil)
+	}
+	if fmpKey != "" {
+		fsReg.Register(fmp.NewFMP(fmpKey), 1)
+	}
+
+	sectorsKey, err := settings.GetSetting(ctx, "sectors_api_key")
+	if err != nil {
+		applog.Warn("read Sectors API key", err, nil)
+	}
+	if sectorsKey != "" {
+		fsReg.Register(sectorsapp.NewSectorsApp(sectorsKey), 2)
+	}
+
+	return fsReg
 }
 
 // releaseCheckerAdapter bridges github.Client to usecase.ReleaseChecker.

--- a/backend/domain/financials/entity.go
+++ b/backend/domain/financials/entity.go
@@ -1,0 +1,76 @@
+package financials
+
+import "time"
+
+// PeriodType distinguishes annual from quarterly financial data.
+type PeriodType string
+
+const (
+	PeriodAnnual    PeriodType = "annual"
+	PeriodQuarterly PeriodType = "quarterly"
+)
+
+// IncomeStatement holds income statement data for a single fiscal period.
+type IncomeStatement struct {
+	ID                string
+	Ticker            string
+	Source            string
+	FiscalYear        int
+	Quarter           int // 0 for annual
+	Period            PeriodType
+	FetchedAt         time.Time
+	Revenue           float64
+	CostOfRevenue     float64
+	GrossProfit       float64
+	OperatingExpenses float64
+	OperatingIncome   float64
+	NetIncome         float64
+	EPS               float64
+	EPSDiluted        float64
+	EBITDA            float64
+	InterestExpense   float64
+	IncomeTaxExpense  float64
+}
+
+// BalanceSheet holds balance sheet data for a single fiscal period.
+type BalanceSheet struct {
+	ID                 string
+	Ticker             string
+	Source             string
+	FiscalYear         int
+	Quarter            int
+	Period             PeriodType
+	FetchedAt          time.Time
+	TotalAssets        float64
+	TotalCurrentAssets float64
+	CashAndEquivalents float64
+	Receivables        float64
+	Inventory          float64
+	IntangibleAssets   float64
+	TotalLiabilities   float64
+	TotalCurrentLiab   float64
+	LongTermDebt       float64
+	TotalDebt          float64
+	TotalEquity        float64
+	RetainedEarnings   float64
+	SharesOutstanding  float64
+}
+
+// CashFlowStatement holds cash flow statement data for a single fiscal period.
+type CashFlowStatement struct {
+	ID                 string
+	Ticker             string
+	Source             string
+	FiscalYear         int
+	Quarter            int
+	Period             PeriodType
+	FetchedAt          time.Time
+	OperatingCashFlow  float64
+	CapitalExpenditure float64
+	FreeCashFlow       float64
+	DividendsPaid      float64
+	NetBorrowings      float64
+	InvestingCashFlow  float64
+	FinancingCashFlow  float64
+	NetChangeInCash    float64
+}

--- a/backend/domain/financials/errors.go
+++ b/backend/domain/financials/errors.go
@@ -1,0 +1,10 @@
+package financials
+
+import "errors"
+
+var (
+	ErrNoStatements = errors.New("no financial statements available")
+	ErrRateLimited  = errors.New("rate limited")
+	ErrSourceDown   = errors.New("financial data source unavailable")
+	ErrInvalidKey   = errors.New("invalid API key")
+)

--- a/backend/domain/financials/provider.go
+++ b/backend/domain/financials/provider.go
@@ -1,0 +1,16 @@
+package financials
+
+import "context"
+
+// FinancialStatementProvider defines operations for fetching full financial
+// statement data from an external source.
+type FinancialStatementProvider interface {
+	// Source returns the provider identifier (e.g. "fmp", "sectors").
+	Source() string
+	// FetchIncomeStatements returns income statements for a ticker and period type.
+	FetchIncomeStatements(ctx context.Context, ticker string, period PeriodType) ([]IncomeStatement, error)
+	// FetchBalanceSheets returns balance sheets for a ticker and period type.
+	FetchBalanceSheets(ctx context.Context, ticker string, period PeriodType) ([]BalanceSheet, error)
+	// FetchCashFlowStatements returns cash flow statements for a ticker and period type.
+	FetchCashFlowStatements(ctx context.Context, ticker string, period PeriodType) ([]CashFlowStatement, error)
+}

--- a/backend/domain/financials/registry.go
+++ b/backend/domain/financials/registry.go
@@ -1,0 +1,14 @@
+package financials
+
+import (
+	"context"
+
+	"github.com/lugassawan/panen/backend/domain/provider"
+)
+
+// Registry provides read and control operations over registered financial statement providers.
+type Registry interface {
+	List() []provider.Info
+	SetEnabled(name string, enabled bool) bool
+	HealthCheckAll(ctx context.Context)
+}

--- a/backend/domain/financials/repository.go
+++ b/backend/domain/financials/repository.go
@@ -1,0 +1,27 @@
+package financials
+
+import (
+	"context"
+	"time"
+)
+
+// IncomeStatementRepo persists income statement data.
+type IncomeStatementRepo interface {
+	BulkUpsert(ctx context.Context, stmts []IncomeStatement) error
+	GetByTicker(ctx context.Context, ticker, source string, period PeriodType) ([]IncomeStatement, error)
+	LatestFetchedAt(ctx context.Context, ticker, source string) (time.Time, error)
+}
+
+// BalanceSheetRepo persists balance sheet data.
+type BalanceSheetRepo interface {
+	BulkUpsert(ctx context.Context, sheets []BalanceSheet) error
+	GetByTicker(ctx context.Context, ticker, source string, period PeriodType) ([]BalanceSheet, error)
+	LatestFetchedAt(ctx context.Context, ticker, source string) (time.Time, error)
+}
+
+// CashFlowStatementRepo persists cash flow statement data.
+type CashFlowStatementRepo interface {
+	BulkUpsert(ctx context.Context, stmts []CashFlowStatement) error
+	GetByTicker(ctx context.Context, ticker, source string, period PeriodType) ([]CashFlowStatement, error)
+	LatestFetchedAt(ctx context.Context, ticker, source string) (time.Time, error)
+}

--- a/backend/infra/database/balance_sheet_repo.go
+++ b/backend/infra/database/balance_sheet_repo.go
@@ -1,0 +1,124 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/lugassawan/panen/backend/domain/financials"
+	"github.com/lugassawan/panen/backend/domain/shared"
+)
+
+const (
+	balanceSheetUpsert = `INSERT INTO balance_sheets
+		(id, ticker, fiscal_year, quarter, period,
+		 total_assets, total_current_assets, cash_and_equivalents, receivables, inventory,
+		 intangible_assets, total_liabilities, total_current_liab, long_term_debt, total_debt,
+		 total_equity, retained_earnings, shares_outstanding,
+		 fetched_at, source)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(ticker, fiscal_year, quarter, source) DO UPDATE SET
+		period = excluded.period,
+		total_assets = excluded.total_assets, total_current_assets = excluded.total_current_assets,
+		cash_and_equivalents = excluded.cash_and_equivalents, receivables = excluded.receivables,
+		inventory = excluded.inventory, intangible_assets = excluded.intangible_assets,
+		total_liabilities = excluded.total_liabilities, total_current_liab = excluded.total_current_liab,
+		long_term_debt = excluded.long_term_debt, total_debt = excluded.total_debt,
+		total_equity = excluded.total_equity, retained_earnings = excluded.retained_earnings,
+		shares_outstanding = excluded.shares_outstanding, fetched_at = excluded.fetched_at`
+	balanceSheetGetByTicker = `SELECT id, ticker, fiscal_year, quarter, period,
+		total_assets, total_current_assets, cash_and_equivalents, receivables, inventory,
+		intangible_assets, total_liabilities, total_current_liab, long_term_debt, total_debt,
+		total_equity, retained_earnings, shares_outstanding,
+		fetched_at, source
+		FROM balance_sheets
+		WHERE ticker = ? AND source = ? AND period = ?
+		ORDER BY fiscal_year DESC, quarter DESC`
+	balanceSheetLatestFetchedAt = `SELECT MAX(fetched_at) FROM balance_sheets
+		WHERE ticker = ? AND source = ?`
+)
+
+// BalanceSheetRepo implements financials.BalanceSheetRepo.
+type BalanceSheetRepo struct {
+	db *sql.DB
+}
+
+// NewBalanceSheetRepo creates a new BalanceSheetRepo.
+func NewBalanceSheetRepo(db *sql.DB) *BalanceSheetRepo {
+	return &BalanceSheetRepo{db: db}
+}
+
+func (r *BalanceSheetRepo) BulkUpsert(ctx context.Context, sheets []financials.BalanceSheet) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+
+	stmt, err := tx.PrepareContext(ctx, balanceSheetUpsert)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for i := range sheets {
+		s := &sheets[i]
+		if s.ID == "" {
+			s.ID = shared.NewID()
+		}
+		_, err := stmt.ExecContext(ctx,
+			s.ID, s.Ticker, s.FiscalYear, s.Quarter, string(s.Period),
+			s.TotalAssets, s.TotalCurrentAssets, s.CashAndEquivalents, s.Receivables, s.Inventory,
+			s.IntangibleAssets, s.TotalLiabilities, s.TotalCurrentLiab, s.LongTermDebt, s.TotalDebt,
+			s.TotalEquity, s.RetainedEarnings, s.SharesOutstanding,
+			formatTime(s.FetchedAt), s.Source)
+		if err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (r *BalanceSheetRepo) GetByTicker(
+	ctx context.Context,
+	ticker, source string,
+	period financials.PeriodType,
+) ([]financials.BalanceSheet, error) {
+	return queryAll(ctx, r.db, balanceSheetGetByTicker, scanBalanceSheet, ticker, source, string(period))
+}
+
+func (r *BalanceSheetRepo) LatestFetchedAt(
+	ctx context.Context,
+	ticker, source string,
+) (time.Time, error) {
+	var dateStr sql.NullString
+	err := r.db.QueryRowContext(ctx, balanceSheetLatestFetchedAt, ticker, source).Scan(&dateStr)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if !dateStr.Valid {
+		return time.Time{}, nil
+	}
+	return parseTime(dateStr.String)
+}
+
+func scanBalanceSheet(scan func(dest ...any) error) (financials.BalanceSheet, error) {
+	var s financials.BalanceSheet
+	var periodStr, fetchedAtStr string
+	if err := scan(
+		&s.ID, &s.Ticker, &s.FiscalYear, &s.Quarter, &periodStr,
+		&s.TotalAssets, &s.TotalCurrentAssets, &s.CashAndEquivalents, &s.Receivables, &s.Inventory,
+		&s.IntangibleAssets, &s.TotalLiabilities, &s.TotalCurrentLiab, &s.LongTermDebt, &s.TotalDebt,
+		&s.TotalEquity, &s.RetainedEarnings, &s.SharesOutstanding,
+		&fetchedAtStr, &s.Source,
+	); err != nil {
+		return s, err
+	}
+	s.Period = financials.PeriodType(periodStr)
+	var err error
+	if s.FetchedAt, err = parseTime(fetchedAtStr); err != nil {
+		return s, err
+	}
+	return s, nil
+}

--- a/backend/infra/database/balance_sheet_repo_test.go
+++ b/backend/infra/database/balance_sheet_repo_test.go
@@ -1,0 +1,170 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lugassawan/panen/backend/domain/financials"
+)
+
+func newBalanceSheetRepo(t *testing.T) (*BalanceSheetRepo, context.Context) {
+	t.Helper()
+	db := newTestDB(t)
+	return NewBalanceSheetRepo(db), context.Background()
+}
+
+func TestBalanceSheetRepoBulkUpsertAndGet(t *testing.T) {
+	repo, ctx := newBalanceSheetRepo(t)
+
+	sheets := []financials.BalanceSheet{
+		{
+			Ticker:      "BBCA",
+			Source:      "fmp",
+			FiscalYear:  2024,
+			Quarter:     0,
+			Period:      financials.PeriodAnnual,
+			FetchedAt:   time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			TotalAssets: 1000000000,
+			TotalEquity: 300000000,
+			TotalDebt:   400000000,
+		},
+		{
+			Ticker:      "BBCA",
+			Source:      "fmp",
+			FiscalYear:  2023,
+			Quarter:     0,
+			Period:      financials.PeriodAnnual,
+			FetchedAt:   time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			TotalAssets: 900000000,
+			TotalEquity: 280000000,
+			TotalDebt:   350000000,
+		},
+	}
+
+	if err := repo.BulkUpsert(ctx, sheets); err != nil {
+		t.Fatalf("BulkUpsert() error = %v", err)
+	}
+
+	got, err := repo.GetByTicker(ctx, "BBCA", "fmp", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("GetByTicker() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	if got[0].FiscalYear != 2024 {
+		t.Errorf("got[0].FiscalYear = %d, want 2024", got[0].FiscalYear)
+	}
+	if got[0].TotalAssets != 1000000000 {
+		t.Errorf("got[0].TotalAssets = %v, want 1000000000", got[0].TotalAssets)
+	}
+}
+
+func TestBalanceSheetRepoBulkUpsertUpdatesExisting(t *testing.T) {
+	repo, ctx := newBalanceSheetRepo(t)
+
+	sheets := []financials.BalanceSheet{
+		{
+			Ticker: "BBCA", Source: "fmp", FiscalYear: 2024, Period: financials.PeriodAnnual,
+			FetchedAt:   time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			TotalAssets: 1000000000, TotalEquity: 300000000,
+		},
+	}
+	if err := repo.BulkUpsert(ctx, sheets); err != nil {
+		t.Fatalf("BulkUpsert() insert error = %v", err)
+	}
+
+	// Update both assets and equity to verify multi-field update
+	sheets[0].TotalAssets = 1100000000
+	sheets[0].TotalEquity = 350000000
+	sheets[0].ID = ""
+	if err := repo.BulkUpsert(ctx, sheets); err != nil {
+		t.Fatalf("BulkUpsert() update error = %v", err)
+	}
+
+	got, err := repo.GetByTicker(ctx, "BBCA", "fmp", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("GetByTicker() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].TotalAssets != 1100000000 {
+		t.Errorf("TotalAssets = %v, want 1100000000", got[0].TotalAssets)
+	}
+	if got[0].TotalEquity != 350000000 {
+		t.Errorf("TotalEquity = %v, want 350000000", got[0].TotalEquity)
+	}
+}
+
+func TestBalanceSheetRepoLatestFetchedAt(t *testing.T) {
+	repo, ctx := newBalanceSheetRepo(t)
+
+	// No data yet — should return zero time.
+	latest, err := repo.LatestFetchedAt(ctx, "BBCA", "fmp")
+	if err != nil {
+		t.Fatalf("LatestFetchedAt() error = %v", err)
+	}
+	if !latest.IsZero() {
+		t.Errorf("LatestFetchedAt() = %v, want zero", latest)
+	}
+
+	// Insert two periods — latest should be the most recent fetched_at across both.
+	sheets := []financials.BalanceSheet{
+		{
+			Ticker: "BBCA", Source: "fmp", FiscalYear: 2023, Period: financials.PeriodAnnual,
+			FetchedAt: time.Date(2025, 1, 10, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Ticker: "BBCA", Source: "fmp", FiscalYear: 2024, Period: financials.PeriodAnnual,
+			FetchedAt: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	if err := repo.BulkUpsert(ctx, sheets); err != nil {
+		t.Fatalf("BulkUpsert() error = %v", err)
+	}
+
+	latest, err = repo.LatestFetchedAt(ctx, "BBCA", "fmp")
+	if err != nil {
+		t.Fatalf("LatestFetchedAt() error = %v", err)
+	}
+	want := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	if !latest.Equal(want) {
+		t.Errorf("LatestFetchedAt() = %v, want %v", latest, want)
+	}
+}
+
+func TestBalanceSheetRepoSourceIsolation(t *testing.T) {
+	repo, ctx := newBalanceSheetRepo(t)
+
+	sheets := []financials.BalanceSheet{
+		{
+			Ticker: "BBCA", Source: "fmp", FiscalYear: 2024, Period: financials.PeriodAnnual,
+			FetchedAt: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC), TotalAssets: 1000000000,
+		},
+		{
+			Ticker: "BBCA", Source: "sectors", FiscalYear: 2024, Period: financials.PeriodAnnual,
+			FetchedAt: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC), TotalAssets: 1010000000,
+		},
+	}
+	if err := repo.BulkUpsert(ctx, sheets); err != nil {
+		t.Fatalf("BulkUpsert() error = %v", err)
+	}
+
+	fmp, err := repo.GetByTicker(ctx, "BBCA", "fmp", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("GetByTicker(fmp) error = %v", err)
+	}
+	if len(fmp) != 1 || fmp[0].TotalAssets != 1000000000 {
+		t.Errorf("fmp data = %v, want 1 record with TotalAssets=1000000000", fmp)
+	}
+
+	sectors, err := repo.GetByTicker(ctx, "BBCA", "sectors", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("GetByTicker(sectors) error = %v", err)
+	}
+	if len(sectors) != 1 || sectors[0].TotalAssets != 1010000000 {
+		t.Errorf("sectors data = %v, want 1 record with TotalAssets=1010000000", sectors)
+	}
+}

--- a/backend/infra/database/cash_flow_stmt_repo.go
+++ b/backend/infra/database/cash_flow_stmt_repo.go
@@ -1,0 +1,118 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/lugassawan/panen/backend/domain/financials"
+	"github.com/lugassawan/panen/backend/domain/shared"
+)
+
+const (
+	cashFlowStmtUpsert = `INSERT INTO cash_flow_statements
+		(id, ticker, fiscal_year, quarter, period,
+		 operating_cash_flow, capital_expenditure, free_cash_flow, dividends_paid, net_borrowings,
+		 investing_cash_flow, financing_cash_flow, net_change_in_cash,
+		 fetched_at, source)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(ticker, fiscal_year, quarter, source) DO UPDATE SET
+		period = excluded.period,
+		operating_cash_flow = excluded.operating_cash_flow, capital_expenditure = excluded.capital_expenditure,
+		free_cash_flow = excluded.free_cash_flow, dividends_paid = excluded.dividends_paid,
+		net_borrowings = excluded.net_borrowings, investing_cash_flow = excluded.investing_cash_flow,
+		financing_cash_flow = excluded.financing_cash_flow, net_change_in_cash = excluded.net_change_in_cash,
+		fetched_at = excluded.fetched_at`
+	cashFlowStmtGetByTicker = `SELECT id, ticker, fiscal_year, quarter, period,
+		operating_cash_flow, capital_expenditure, free_cash_flow, dividends_paid, net_borrowings,
+		investing_cash_flow, financing_cash_flow, net_change_in_cash,
+		fetched_at, source
+		FROM cash_flow_statements
+		WHERE ticker = ? AND source = ? AND period = ?
+		ORDER BY fiscal_year DESC, quarter DESC`
+	cashFlowStmtLatestFetchedAt = `SELECT MAX(fetched_at) FROM cash_flow_statements
+		WHERE ticker = ? AND source = ?`
+)
+
+// CashFlowStatementRepo implements financials.CashFlowStatementRepo.
+type CashFlowStatementRepo struct {
+	db *sql.DB
+}
+
+// NewCashFlowStatementRepo creates a new CashFlowStatementRepo.
+func NewCashFlowStatementRepo(db *sql.DB) *CashFlowStatementRepo {
+	return &CashFlowStatementRepo{db: db}
+}
+
+func (r *CashFlowStatementRepo) BulkUpsert(ctx context.Context, stmts []financials.CashFlowStatement) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+
+	stmt, err := tx.PrepareContext(ctx, cashFlowStmtUpsert)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for i := range stmts {
+		s := &stmts[i]
+		if s.ID == "" {
+			s.ID = shared.NewID()
+		}
+		_, err := stmt.ExecContext(ctx,
+			s.ID, s.Ticker, s.FiscalYear, s.Quarter, string(s.Period),
+			s.OperatingCashFlow, s.CapitalExpenditure, s.FreeCashFlow, s.DividendsPaid, s.NetBorrowings,
+			s.InvestingCashFlow, s.FinancingCashFlow, s.NetChangeInCash,
+			formatTime(s.FetchedAt), s.Source)
+		if err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (r *CashFlowStatementRepo) GetByTicker(
+	ctx context.Context,
+	ticker, source string,
+	period financials.PeriodType,
+) ([]financials.CashFlowStatement, error) {
+	return queryAll(ctx, r.db, cashFlowStmtGetByTicker, scanCashFlowStatement, ticker, source, string(period))
+}
+
+func (r *CashFlowStatementRepo) LatestFetchedAt(
+	ctx context.Context,
+	ticker, source string,
+) (time.Time, error) {
+	var dateStr sql.NullString
+	err := r.db.QueryRowContext(ctx, cashFlowStmtLatestFetchedAt, ticker, source).Scan(&dateStr)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if !dateStr.Valid {
+		return time.Time{}, nil
+	}
+	return parseTime(dateStr.String)
+}
+
+func scanCashFlowStatement(scan func(dest ...any) error) (financials.CashFlowStatement, error) {
+	var s financials.CashFlowStatement
+	var periodStr, fetchedAtStr string
+	if err := scan(
+		&s.ID, &s.Ticker, &s.FiscalYear, &s.Quarter, &periodStr,
+		&s.OperatingCashFlow, &s.CapitalExpenditure, &s.FreeCashFlow, &s.DividendsPaid, &s.NetBorrowings,
+		&s.InvestingCashFlow, &s.FinancingCashFlow, &s.NetChangeInCash,
+		&fetchedAtStr, &s.Source,
+	); err != nil {
+		return s, err
+	}
+	s.Period = financials.PeriodType(periodStr)
+	var err error
+	if s.FetchedAt, err = parseTime(fetchedAtStr); err != nil {
+		return s, err
+	}
+	return s, nil
+}

--- a/backend/infra/database/cash_flow_stmt_repo_test.go
+++ b/backend/infra/database/cash_flow_stmt_repo_test.go
@@ -1,0 +1,145 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lugassawan/panen/backend/domain/financials"
+)
+
+func newCashFlowStatementRepo(t *testing.T) (*CashFlowStatementRepo, context.Context) {
+	t.Helper()
+	db := newTestDB(t)
+	return NewCashFlowStatementRepo(db), context.Background()
+}
+
+func TestCashFlowStatementRepoBulkUpsertAndGet(t *testing.T) {
+	repo, ctx := newCashFlowStatementRepo(t)
+
+	stmts := []financials.CashFlowStatement{
+		{
+			Ticker:            "BBCA",
+			Source:            "fmp",
+			FiscalYear:        2024,
+			Quarter:           0,
+			Period:            financials.PeriodAnnual,
+			FetchedAt:         time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			OperatingCashFlow: 20000000,
+			FreeCashFlow:      15000000,
+			DividendsPaid:     5000000,
+		},
+		{
+			Ticker:            "BBCA",
+			Source:            "fmp",
+			FiscalYear:        2023,
+			Quarter:           0,
+			Period:            financials.PeriodAnnual,
+			FetchedAt:         time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			OperatingCashFlow: 18000000,
+			FreeCashFlow:      13000000,
+			DividendsPaid:     4500000,
+		},
+	}
+
+	if err := repo.BulkUpsert(ctx, stmts); err != nil {
+		t.Fatalf("BulkUpsert() error = %v", err)
+	}
+
+	got, err := repo.GetByTicker(ctx, "BBCA", "fmp", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("GetByTicker() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	if got[0].FiscalYear != 2024 {
+		t.Errorf("got[0].FiscalYear = %d, want 2024", got[0].FiscalYear)
+	}
+	if got[0].OperatingCashFlow != 20000000 {
+		t.Errorf("got[0].OperatingCashFlow = %v, want 20000000", got[0].OperatingCashFlow)
+	}
+	if got[1].FreeCashFlow != 13000000 {
+		t.Errorf("got[1].FreeCashFlow = %v, want 13000000", got[1].FreeCashFlow)
+	}
+}
+
+func TestCashFlowStatementRepoBulkUpsertUpdatesExisting(t *testing.T) {
+	repo, ctx := newCashFlowStatementRepo(t)
+
+	stmts := []financials.CashFlowStatement{
+		{
+			Ticker: "BBCA", Source: "fmp", FiscalYear: 2024, Period: financials.PeriodAnnual,
+			FetchedAt:         time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			FreeCashFlow:      15000000,
+			OperatingCashFlow: 20000000,
+		},
+	}
+	if err := repo.BulkUpsert(ctx, stmts); err != nil {
+		t.Fatalf("BulkUpsert() insert error = %v", err)
+	}
+
+	stmts[0].FreeCashFlow = 16000000
+	stmts[0].OperatingCashFlow = 22000000
+	stmts[0].ID = ""
+	if err := repo.BulkUpsert(ctx, stmts); err != nil {
+		t.Fatalf("BulkUpsert() update error = %v", err)
+	}
+
+	got, err := repo.GetByTicker(ctx, "BBCA", "fmp", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("GetByTicker() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].FreeCashFlow != 16000000 {
+		t.Errorf("FreeCashFlow = %v, want 16000000", got[0].FreeCashFlow)
+	}
+	if got[0].OperatingCashFlow != 22000000 {
+		t.Errorf("OperatingCashFlow = %v, want 22000000", got[0].OperatingCashFlow)
+	}
+}
+
+func TestCashFlowStatementRepoLatestFetchedAt(t *testing.T) {
+	repo, ctx := newCashFlowStatementRepo(t)
+
+	latest, err := repo.LatestFetchedAt(ctx, "BBCA", "fmp")
+	if err != nil {
+		t.Fatalf("LatestFetchedAt() error = %v", err)
+	}
+	if !latest.IsZero() {
+		t.Errorf("LatestFetchedAt() = %v, want zero", latest)
+	}
+
+	stmts := []financials.CashFlowStatement{
+		{
+			Ticker: "BBCA", Source: "fmp", FiscalYear: 2024, Period: financials.PeriodAnnual,
+			FetchedAt: time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	if err := repo.BulkUpsert(ctx, stmts); err != nil {
+		t.Fatalf("BulkUpsert() error = %v", err)
+	}
+
+	latest, err = repo.LatestFetchedAt(ctx, "BBCA", "fmp")
+	if err != nil {
+		t.Fatalf("LatestFetchedAt() error = %v", err)
+	}
+	want := time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC)
+	if !latest.Equal(want) {
+		t.Errorf("LatestFetchedAt() = %v, want %v", latest, want)
+	}
+}
+
+func TestCashFlowStatementRepoGetByTickerEmpty(t *testing.T) {
+	repo, ctx := newCashFlowStatementRepo(t)
+
+	got, err := repo.GetByTicker(ctx, "NONEXIST", "fmp", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("GetByTicker() error = %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}

--- a/backend/infra/database/income_stmt_repo.go
+++ b/backend/infra/database/income_stmt_repo.go
@@ -1,0 +1,119 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/lugassawan/panen/backend/domain/financials"
+	"github.com/lugassawan/panen/backend/domain/shared"
+)
+
+const (
+	incomeStmtUpsert = `INSERT INTO income_statements
+		(id, ticker, fiscal_year, quarter, period,
+		 revenue, cost_of_revenue, gross_profit, operating_expenses, operating_income,
+		 net_income, eps, eps_diluted, ebitda, interest_expense, income_tax_expense,
+		 fetched_at, source)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(ticker, fiscal_year, quarter, source) DO UPDATE SET
+		period = excluded.period,
+		revenue = excluded.revenue, cost_of_revenue = excluded.cost_of_revenue,
+		gross_profit = excluded.gross_profit, operating_expenses = excluded.operating_expenses,
+		operating_income = excluded.operating_income, net_income = excluded.net_income,
+		eps = excluded.eps, eps_diluted = excluded.eps_diluted,
+		ebitda = excluded.ebitda, interest_expense = excluded.interest_expense,
+		income_tax_expense = excluded.income_tax_expense, fetched_at = excluded.fetched_at`
+	incomeStmtGetByTicker = `SELECT id, ticker, fiscal_year, quarter, period,
+		revenue, cost_of_revenue, gross_profit, operating_expenses, operating_income,
+		net_income, eps, eps_diluted, ebitda, interest_expense, income_tax_expense,
+		fetched_at, source
+		FROM income_statements
+		WHERE ticker = ? AND source = ? AND period = ?
+		ORDER BY fiscal_year DESC, quarter DESC`
+	incomeStmtLatestFetchedAt = `SELECT MAX(fetched_at) FROM income_statements
+		WHERE ticker = ? AND source = ?`
+)
+
+// IncomeStatementRepo implements financials.IncomeStatementRepo.
+type IncomeStatementRepo struct {
+	db *sql.DB
+}
+
+// NewIncomeStatementRepo creates a new IncomeStatementRepo.
+func NewIncomeStatementRepo(db *sql.DB) *IncomeStatementRepo {
+	return &IncomeStatementRepo{db: db}
+}
+
+func (r *IncomeStatementRepo) BulkUpsert(ctx context.Context, stmts []financials.IncomeStatement) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+
+	stmt, err := tx.PrepareContext(ctx, incomeStmtUpsert)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for i := range stmts {
+		s := &stmts[i]
+		if s.ID == "" {
+			s.ID = shared.NewID()
+		}
+		_, err := stmt.ExecContext(ctx,
+			s.ID, s.Ticker, s.FiscalYear, s.Quarter, string(s.Period),
+			s.Revenue, s.CostOfRevenue, s.GrossProfit, s.OperatingExpenses, s.OperatingIncome,
+			s.NetIncome, s.EPS, s.EPSDiluted, s.EBITDA, s.InterestExpense, s.IncomeTaxExpense,
+			formatTime(s.FetchedAt), s.Source)
+		if err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (r *IncomeStatementRepo) GetByTicker(
+	ctx context.Context,
+	ticker, source string,
+	period financials.PeriodType,
+) ([]financials.IncomeStatement, error) {
+	return queryAll(ctx, r.db, incomeStmtGetByTicker, scanIncomeStatement, ticker, source, string(period))
+}
+
+func (r *IncomeStatementRepo) LatestFetchedAt(
+	ctx context.Context,
+	ticker, source string,
+) (time.Time, error) {
+	var dateStr sql.NullString
+	err := r.db.QueryRowContext(ctx, incomeStmtLatestFetchedAt, ticker, source).Scan(&dateStr)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if !dateStr.Valid {
+		return time.Time{}, nil
+	}
+	return parseTime(dateStr.String)
+}
+
+func scanIncomeStatement(scan func(dest ...any) error) (financials.IncomeStatement, error) {
+	var s financials.IncomeStatement
+	var periodStr, fetchedAtStr string
+	if err := scan(
+		&s.ID, &s.Ticker, &s.FiscalYear, &s.Quarter, &periodStr,
+		&s.Revenue, &s.CostOfRevenue, &s.GrossProfit, &s.OperatingExpenses, &s.OperatingIncome,
+		&s.NetIncome, &s.EPS, &s.EPSDiluted, &s.EBITDA, &s.InterestExpense, &s.IncomeTaxExpense,
+		&fetchedAtStr, &s.Source,
+	); err != nil {
+		return s, err
+	}
+	s.Period = financials.PeriodType(periodStr)
+	var err error
+	if s.FetchedAt, err = parseTime(fetchedAtStr); err != nil {
+		return s, err
+	}
+	return s, nil
+}

--- a/backend/infra/database/income_stmt_repo_test.go
+++ b/backend/infra/database/income_stmt_repo_test.go
@@ -1,0 +1,183 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lugassawan/panen/backend/domain/financials"
+)
+
+func newIncomeStatementRepo(t *testing.T) (*IncomeStatementRepo, context.Context) {
+	t.Helper()
+	db := newTestDB(t)
+	return NewIncomeStatementRepo(db), context.Background()
+}
+
+func TestIncomeStatementRepoBulkUpsertAndGet(t *testing.T) {
+	repo, ctx := newIncomeStatementRepo(t)
+
+	stmts := []financials.IncomeStatement{
+		{
+			Ticker:     "BBCA",
+			Source:     "fmp",
+			FiscalYear: 2024,
+			Quarter:    0,
+			Period:     financials.PeriodAnnual,
+			FetchedAt:  time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			Revenue:    50000000,
+			NetIncome:  15000000,
+			EPS:        500,
+		},
+		{
+			Ticker:     "BBCA",
+			Source:     "fmp",
+			FiscalYear: 2023,
+			Quarter:    0,
+			Period:     financials.PeriodAnnual,
+			FetchedAt:  time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			Revenue:    45000000,
+			NetIncome:  13000000,
+			EPS:        450,
+		},
+	}
+
+	if err := repo.BulkUpsert(ctx, stmts); err != nil {
+		t.Fatalf("BulkUpsert() error = %v", err)
+	}
+
+	got, err := repo.GetByTicker(ctx, "BBCA", "fmp", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("GetByTicker() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	// Ordered by fiscal_year DESC
+	if got[0].FiscalYear != 2024 {
+		t.Errorf("got[0].FiscalYear = %d, want 2024", got[0].FiscalYear)
+	}
+	if got[0].Revenue != 50000000 {
+		t.Errorf("got[0].Revenue = %v, want 50000000", got[0].Revenue)
+	}
+	if got[0].NetIncome != 15000000 {
+		t.Errorf("got[0].NetIncome = %v, want 15000000", got[0].NetIncome)
+	}
+	if got[0].EPS != 500 {
+		t.Errorf("got[0].EPS = %v, want 500", got[0].EPS)
+	}
+	if got[0].Period != financials.PeriodAnnual {
+		t.Errorf("got[0].Period = %q, want annual", got[0].Period)
+	}
+	if got[1].EPS != 450 {
+		t.Errorf("got[1].EPS = %v, want 450", got[1].EPS)
+	}
+}
+
+func TestIncomeStatementRepoBulkUpsertUpdatesExisting(t *testing.T) {
+	repo, ctx := newIncomeStatementRepo(t)
+
+	stmts := []financials.IncomeStatement{
+		{
+			Ticker:     "BBCA",
+			Source:     "fmp",
+			FiscalYear: 2024,
+			Quarter:    0,
+			Period:     financials.PeriodAnnual,
+			FetchedAt:  time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			Revenue:    50000000,
+		},
+	}
+	if err := repo.BulkUpsert(ctx, stmts); err != nil {
+		t.Fatalf("BulkUpsert() insert error = %v", err)
+	}
+
+	stmts[0].Revenue = 55000000
+	stmts[0].ID = ""
+	if err := repo.BulkUpsert(ctx, stmts); err != nil {
+		t.Fatalf("BulkUpsert() update error = %v", err)
+	}
+
+	got, err := repo.GetByTicker(ctx, "BBCA", "fmp", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("GetByTicker() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].Revenue != 55000000 {
+		t.Errorf("Revenue = %v, want 55000000", got[0].Revenue)
+	}
+}
+
+func TestIncomeStatementRepoLatestFetchedAt(t *testing.T) {
+	repo, ctx := newIncomeStatementRepo(t)
+
+	// No data yet — should return zero time.
+	latest, err := repo.LatestFetchedAt(ctx, "BBCA", "fmp")
+	if err != nil {
+		t.Fatalf("LatestFetchedAt() error = %v", err)
+	}
+	if !latest.IsZero() {
+		t.Errorf("LatestFetchedAt() = %v, want zero", latest)
+	}
+
+	stmts := []financials.IncomeStatement{
+		{
+			Ticker: "BBCA", Source: "fmp", FiscalYear: 2023, Period: financials.PeriodAnnual,
+			FetchedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Ticker: "BBCA", Source: "fmp", FiscalYear: 2024, Period: financials.PeriodAnnual,
+			FetchedAt: time.Date(2025, 3, 15, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	if err := repo.BulkUpsert(ctx, stmts); err != nil {
+		t.Fatalf("BulkUpsert() error = %v", err)
+	}
+
+	latest, err = repo.LatestFetchedAt(ctx, "BBCA", "fmp")
+	if err != nil {
+		t.Fatalf("LatestFetchedAt() error = %v", err)
+	}
+	want := time.Date(2025, 3, 15, 0, 0, 0, 0, time.UTC)
+	if !latest.Equal(want) {
+		t.Errorf("LatestFetchedAt() = %v, want %v", latest, want)
+	}
+}
+
+func TestIncomeStatementRepoPeriodIsolation(t *testing.T) {
+	repo, ctx := newIncomeStatementRepo(t)
+
+	stmts := []financials.IncomeStatement{
+		{
+			Ticker: "BBCA", Source: "fmp", FiscalYear: 2024, Quarter: 0,
+			Period: financials.PeriodAnnual, FetchedAt: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			Revenue: 50000000,
+		},
+		{
+			Ticker: "BBCA", Source: "fmp", FiscalYear: 2024, Quarter: 1,
+			Period: financials.PeriodQuarterly, FetchedAt: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			Revenue: 12000000,
+		},
+	}
+	if err := repo.BulkUpsert(ctx, stmts); err != nil {
+		t.Fatalf("BulkUpsert() error = %v", err)
+	}
+
+	annual, err := repo.GetByTicker(ctx, "BBCA", "fmp", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("GetByTicker(annual) error = %v", err)
+	}
+	if len(annual) != 1 || annual[0].Revenue != 50000000 {
+		t.Errorf("annual = %v, want 1 record with Revenue=50000000", annual)
+	}
+
+	quarterly, err := repo.GetByTicker(ctx, "BBCA", "fmp", financials.PeriodQuarterly)
+	if err != nil {
+		t.Fatalf("GetByTicker(quarterly) error = %v", err)
+	}
+	if len(quarterly) != 1 || quarterly[0].Revenue != 12000000 {
+		t.Errorf("quarterly = %v, want 1 record with Revenue=12000000", quarterly)
+	}
+}

--- a/backend/infra/database/schema.go
+++ b/backend/infra/database/schema.go
@@ -14,6 +14,7 @@ var migrations = []string{
 	migrationV10,
 	migrationV11,
 	migrationV12,
+	migrationV13,
 }
 
 const migrationV1 = `
@@ -261,4 +262,74 @@ CREATE TABLE sell_transactions (
 	created_at    TEXT NOT NULL
 );
 CREATE INDEX idx_sell_transactions_holding ON sell_transactions(holding_id);
+`
+
+const migrationV13 = `
+CREATE TABLE income_statements (
+	id                 TEXT PRIMARY KEY,
+	ticker             TEXT NOT NULL,
+	fiscal_year        INTEGER NOT NULL,
+	quarter            INTEGER NOT NULL DEFAULT 0,
+	period             TEXT NOT NULL CHECK(period IN ('annual','quarterly')),
+	revenue            REAL NOT NULL DEFAULT 0,
+	cost_of_revenue    REAL NOT NULL DEFAULT 0,
+	gross_profit       REAL NOT NULL DEFAULT 0,
+	operating_expenses REAL NOT NULL DEFAULT 0,
+	operating_income   REAL NOT NULL DEFAULT 0,
+	net_income         REAL NOT NULL DEFAULT 0,
+	eps                REAL NOT NULL DEFAULT 0,
+	eps_diluted        REAL NOT NULL DEFAULT 0,
+	ebitda             REAL NOT NULL DEFAULT 0,
+	interest_expense   REAL NOT NULL DEFAULT 0,
+	income_tax_expense REAL NOT NULL DEFAULT 0,
+	fetched_at         TEXT NOT NULL,
+	source             TEXT NOT NULL,
+	UNIQUE(ticker, fiscal_year, quarter, source)
+);
+CREATE INDEX idx_income_stmts_ticker ON income_statements(ticker, fiscal_year);
+
+CREATE TABLE balance_sheets (
+	id                      TEXT PRIMARY KEY,
+	ticker                  TEXT NOT NULL,
+	fiscal_year             INTEGER NOT NULL,
+	quarter                 INTEGER NOT NULL DEFAULT 0,
+	period                  TEXT NOT NULL CHECK(period IN ('annual','quarterly')),
+	total_assets            REAL NOT NULL DEFAULT 0,
+	total_current_assets    REAL NOT NULL DEFAULT 0,
+	cash_and_equivalents    REAL NOT NULL DEFAULT 0,
+	receivables             REAL NOT NULL DEFAULT 0,
+	inventory               REAL NOT NULL DEFAULT 0,
+	intangible_assets       REAL NOT NULL DEFAULT 0,
+	total_liabilities       REAL NOT NULL DEFAULT 0,
+	total_current_liab      REAL NOT NULL DEFAULT 0,
+	long_term_debt          REAL NOT NULL DEFAULT 0,
+	total_debt              REAL NOT NULL DEFAULT 0,
+	total_equity            REAL NOT NULL DEFAULT 0,
+	retained_earnings       REAL NOT NULL DEFAULT 0,
+	shares_outstanding      REAL NOT NULL DEFAULT 0,
+	fetched_at              TEXT NOT NULL,
+	source                  TEXT NOT NULL,
+	UNIQUE(ticker, fiscal_year, quarter, source)
+);
+CREATE INDEX idx_balance_sheets_ticker ON balance_sheets(ticker, fiscal_year);
+
+CREATE TABLE cash_flow_statements (
+	id                    TEXT PRIMARY KEY,
+	ticker                TEXT NOT NULL,
+	fiscal_year           INTEGER NOT NULL,
+	quarter               INTEGER NOT NULL DEFAULT 0,
+	period                TEXT NOT NULL CHECK(period IN ('annual','quarterly')),
+	operating_cash_flow   REAL NOT NULL DEFAULT 0,
+	capital_expenditure   REAL NOT NULL DEFAULT 0,
+	free_cash_flow        REAL NOT NULL DEFAULT 0,
+	dividends_paid        REAL NOT NULL DEFAULT 0,
+	net_borrowings        REAL NOT NULL DEFAULT 0,
+	investing_cash_flow   REAL NOT NULL DEFAULT 0,
+	financing_cash_flow   REAL NOT NULL DEFAULT 0,
+	net_change_in_cash    REAL NOT NULL DEFAULT 0,
+	fetched_at            TEXT NOT NULL,
+	source                TEXT NOT NULL,
+	UNIQUE(ticker, fiscal_year, quarter, source)
+);
+CREATE INDEX idx_cash_flow_stmts_ticker ON cash_flow_statements(ticker, fiscal_year);
 `

--- a/backend/infra/fmp/fmp.go
+++ b/backend/infra/fmp/fmp.go
@@ -1,0 +1,289 @@
+package fmp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/lugassawan/panen/backend/domain/financials"
+)
+
+const (
+	defaultBaseURL  = "https://financialmodelingprep.com/api/v3"
+	maxResponseSize = 5 << 20 // 5 MB
+	sourceFMP       = "fmp"
+)
+
+// FMP fetches financial statement data from Financial Modeling Prep.
+type FMP struct {
+	client  *http.Client
+	limiter *rate.Limiter
+	baseURL string
+	apiKey  string
+}
+
+// Option configures the FMP provider.
+type Option func(*FMP)
+
+// WithBaseURL overrides the base URL (useful for tests).
+func WithBaseURL(u string) Option {
+	return func(f *FMP) { f.baseURL = u }
+}
+
+// WithRateLimit sets custom rate limiter parameters.
+func WithRateLimit(rps float64, burst int) Option {
+	return func(f *FMP) { f.limiter = rate.NewLimiter(rate.Limit(rps), burst) }
+}
+
+// WithHTTPClient overrides the HTTP client (useful for tests).
+func WithHTTPClient(c *http.Client) Option {
+	return func(f *FMP) { f.client = c }
+}
+
+// NewFMP creates an FMP provider with the given API key and options.
+func NewFMP(apiKey string, opts ...Option) *FMP {
+	f := &FMP{
+		limiter: rate.NewLimiter(4, 8),
+		baseURL: defaultBaseURL,
+		apiKey:  apiKey,
+	}
+	for _, o := range opts {
+		o(f)
+	}
+	if f.client == nil {
+		f.client = &http.Client{}
+	}
+	return f
+}
+
+// Source returns the provider identifier.
+func (f *FMP) Source() string { return sourceFMP }
+
+// FetchIncomeStatements returns income statements for a ticker and period type.
+func (f *FMP) FetchIncomeStatements(
+	ctx context.Context,
+	ticker string,
+	period financials.PeriodType,
+) ([]financials.IncomeStatement, error) {
+	fmpTicker := formatIDXTicker(ticker)
+	reqURL := fmt.Sprintf("%s/income-statement/%s?period=%s&apikey=%s",
+		f.baseURL, fmpTicker, string(period), f.apiKey)
+
+	body, err := f.doGet(ctx, reqURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp []incomeStatementResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("%w: malformed income statement response", financials.ErrNoStatements)
+	}
+
+	if len(resp) == 0 {
+		return nil, fmt.Errorf("%w: empty income statement result", financials.ErrNoStatements)
+	}
+
+	now := time.Now().UTC()
+	stmts := make([]financials.IncomeStatement, len(resp))
+	for i, r := range resp {
+		year, quarter := parseFMPPeriod(r.CalendarYear, r.Period)
+		stmts[i] = financials.IncomeStatement{
+			Ticker:            ticker,
+			Source:            sourceFMP,
+			FiscalYear:        year,
+			Quarter:           quarter,
+			Period:            period,
+			FetchedAt:         now,
+			Revenue:           r.Revenue,
+			CostOfRevenue:     r.CostOfRevenue,
+			GrossProfit:       r.GrossProfit,
+			OperatingExpenses: r.OperatingExpenses,
+			OperatingIncome:   r.OperatingIncome,
+			NetIncome:         r.NetIncome,
+			EPS:               r.EPS,
+			EPSDiluted:        r.EPSDiluted,
+			EBITDA:            r.EBITDA,
+			InterestExpense:   r.InterestExpense,
+			IncomeTaxExpense:  r.IncomeTaxExpense,
+		}
+	}
+	return stmts, nil
+}
+
+// FetchBalanceSheets returns balance sheets for a ticker and period type.
+func (f *FMP) FetchBalanceSheets(
+	ctx context.Context,
+	ticker string,
+	period financials.PeriodType,
+) ([]financials.BalanceSheet, error) {
+	fmpTicker := formatIDXTicker(ticker)
+	reqURL := fmt.Sprintf("%s/balance-sheet-statement/%s?period=%s&apikey=%s",
+		f.baseURL, fmpTicker, string(period), f.apiKey)
+
+	body, err := f.doGet(ctx, reqURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp []balanceSheetResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("%w: malformed balance sheet response", financials.ErrNoStatements)
+	}
+
+	if len(resp) == 0 {
+		return nil, fmt.Errorf("%w: empty balance sheet result", financials.ErrNoStatements)
+	}
+
+	now := time.Now().UTC()
+	sheets := make([]financials.BalanceSheet, len(resp))
+	for i, r := range resp {
+		year, quarter := parseFMPPeriod(r.CalendarYear, r.Period)
+		sheets[i] = financials.BalanceSheet{
+			Ticker:             ticker,
+			Source:             sourceFMP,
+			FiscalYear:         year,
+			Quarter:            quarter,
+			Period:             period,
+			FetchedAt:          now,
+			TotalAssets:        r.TotalAssets,
+			TotalCurrentAssets: r.TotalCurrentAssets,
+			CashAndEquivalents: r.CashAndCashEquivalents,
+			Receivables:        r.NetReceivables,
+			Inventory:          r.Inventory,
+			IntangibleAssets:   r.IntangibleAssets,
+			TotalLiabilities:   r.TotalLiabilities,
+			TotalCurrentLiab:   r.TotalCurrentLiabilities,
+			LongTermDebt:       r.LongTermDebt,
+			TotalDebt:          r.TotalDebt,
+			TotalEquity:        r.TotalStockholdersEquity,
+			RetainedEarnings:   r.RetainedEarnings,
+			SharesOutstanding:  r.CommonStockSharesOutstanding,
+		}
+	}
+	return sheets, nil
+}
+
+// FetchCashFlowStatements returns cash flow statements for a ticker and period type.
+func (f *FMP) FetchCashFlowStatements(
+	ctx context.Context,
+	ticker string,
+	period financials.PeriodType,
+) ([]financials.CashFlowStatement, error) {
+	fmpTicker := formatIDXTicker(ticker)
+	reqURL := fmt.Sprintf("%s/cash-flow-statement/%s?period=%s&apikey=%s",
+		f.baseURL, fmpTicker, string(period), f.apiKey)
+
+	body, err := f.doGet(ctx, reqURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp []cashFlowResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("%w: malformed cash flow response", financials.ErrNoStatements)
+	}
+
+	if len(resp) == 0 {
+		return nil, fmt.Errorf("%w: empty cash flow result", financials.ErrNoStatements)
+	}
+
+	now := time.Now().UTC()
+	stmts := make([]financials.CashFlowStatement, len(resp))
+	for i, r := range resp {
+		year, quarter := parseFMPPeriod(r.CalendarYear, r.Period)
+		stmts[i] = financials.CashFlowStatement{
+			Ticker:             ticker,
+			Source:             sourceFMP,
+			FiscalYear:         year,
+			Quarter:            quarter,
+			Period:             period,
+			FetchedAt:          now,
+			OperatingCashFlow:  r.OperatingCashFlow,
+			CapitalExpenditure: r.CapitalExpenditure,
+			FreeCashFlow:       r.FreeCashFlow,
+			DividendsPaid:      r.DividendsPaid,
+			NetBorrowings:      r.DebtRepayment,
+			InvestingCashFlow:  r.NetCashUsedForInvestingActivites,
+			FinancingCashFlow:  r.NetCashUsedProvidedByFinancingActivities,
+			NetChangeInCash:    r.NetChangeInCash,
+		}
+	}
+	return stmts, nil
+}
+
+func (f *FMP) doGet(ctx context.Context, reqURL string) ([]byte, error) {
+	if err := f.limiter.Wait(ctx); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := f.client.Do(req) //nolint:gosec // URL is constructed from controlled baseURL + ticker
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if err := mapHTTPError(resp.StatusCode); err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func mapHTTPError(code int) error {
+	switch {
+	case code == http.StatusOK:
+		return nil
+	case code == http.StatusForbidden:
+		return financials.ErrInvalidKey
+	case code == http.StatusTooManyRequests:
+		return financials.ErrRateLimited
+	case code >= 500:
+		return financials.ErrSourceDown
+	default:
+		return fmt.Errorf("unexpected HTTP status %d", code)
+	}
+}
+
+// formatIDXTicker converts an IDX ticker (e.g. "BBCA") to FMP format ("BBCA.JK").
+func formatIDXTicker(ticker string) string {
+	if strings.HasSuffix(ticker, ".JK") {
+		return ticker
+	}
+	return ticker + ".JK"
+}
+
+// parseFMPPeriod extracts fiscal year and quarter from FMP response fields.
+// FMP returns calendarYear as "2024" and period as "FY", "Q1", "Q2", "Q3", "Q4".
+func parseFMPPeriod(calendarYear, period string) (int, int) {
+	year, _ := strconv.Atoi(calendarYear)
+
+	switch period {
+	case "Q1":
+		return year, 1
+	case "Q2":
+		return year, 2
+	case "Q3":
+		return year, 3
+	case "Q4":
+		return year, 4
+	default:
+		return year, 0
+	}
+}

--- a/backend/infra/fmp/fmp_test.go
+++ b/backend/infra/fmp/fmp_test.go
@@ -1,0 +1,255 @@
+package fmp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lugassawan/panen/backend/domain/financials"
+)
+
+func setupTestServer(t *testing.T, handler http.HandlerFunc) *FMP {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return NewFMP("test-key", WithBaseURL(server.URL), WithHTTPClient(server.Client()))
+}
+
+func TestFMPSource(t *testing.T) {
+	f := NewFMP("key")
+	if got := f.Source(); got != "fmp" {
+		t.Errorf("Source() = %q, want %q", got, "fmp")
+	}
+}
+
+func TestFMPFetchIncomeStatements(t *testing.T) {
+	resp := []incomeStatementResponse{
+		{
+			CalendarYear: "2024",
+			Period:       "FY",
+			Revenue:      50000000,
+			NetIncome:    15000000,
+			EPS:          500,
+			EPSDiluted:   495,
+			EBITDA:       20000000,
+		},
+		{
+			CalendarYear: "2023",
+			Period:       "FY",
+			Revenue:      45000000,
+			NetIncome:    13000000,
+			EPS:          450,
+		},
+	}
+
+	f := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/income-statement/BBCA.JK" {
+			t.Errorf("request path = %q, want /income-statement/BBCA.JK", got)
+		}
+		if got := r.URL.Query().Get("period"); got != "annual" {
+			t.Errorf("period = %q, want annual", got)
+		}
+		if got := r.URL.Query().Get("apikey"); got != "test-key" {
+			t.Errorf("apikey = %q, want test-key", got)
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	stmts, err := f.FetchIncomeStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("FetchIncomeStatements() error = %v", err)
+	}
+	if len(stmts) != 2 {
+		t.Fatalf("len(stmts) = %d, want 2", len(stmts))
+	}
+	if stmts[0].Revenue != 50000000 {
+		t.Errorf("stmts[0].Revenue = %v, want 50000000", stmts[0].Revenue)
+	}
+	if stmts[0].FiscalYear != 2024 {
+		t.Errorf("stmts[0].FiscalYear = %d, want 2024", stmts[0].FiscalYear)
+	}
+	if stmts[0].Quarter != 0 {
+		t.Errorf("stmts[0].Quarter = %d, want 0", stmts[0].Quarter)
+	}
+	if stmts[0].Source != "fmp" {
+		t.Errorf("stmts[0].Source = %q, want fmp", stmts[0].Source)
+	}
+	if stmts[0].Ticker != "BBCA" {
+		t.Errorf("stmts[0].Ticker = %q, want BBCA", stmts[0].Ticker)
+	}
+}
+
+func TestFMPFetchIncomeStatementsQuarterly(t *testing.T) {
+	resp := []incomeStatementResponse{
+		{CalendarYear: "2024", Period: "Q3", Revenue: 13000000},
+		{CalendarYear: "2024", Period: "Q2", Revenue: 12500000},
+		{CalendarYear: "2024", Period: "Q1", Revenue: 12000000},
+	}
+
+	f := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("period"); got != "quarterly" {
+			t.Errorf("period = %q, want quarterly", got)
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	stmts, err := f.FetchIncomeStatements(context.Background(), "BBCA", financials.PeriodQuarterly)
+	if err != nil {
+		t.Fatalf("FetchIncomeStatements() error = %v", err)
+	}
+	if len(stmts) != 3 {
+		t.Fatalf("len(stmts) = %d, want 3", len(stmts))
+	}
+	if stmts[0].Quarter != 3 {
+		t.Errorf("stmts[0].Quarter = %d, want 3", stmts[0].Quarter)
+	}
+}
+
+func TestFMPFetchBalanceSheets(t *testing.T) {
+	resp := []balanceSheetResponse{
+		{
+			CalendarYear:            "2024",
+			Period:                  "FY",
+			TotalAssets:             1000000000,
+			TotalStockholdersEquity: 300000000,
+			TotalDebt:               400000000,
+		},
+	}
+
+	f := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/balance-sheet-statement/BBCA.JK" {
+			t.Errorf("request path = %q, want /balance-sheet-statement/BBCA.JK", got)
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	sheets, err := f.FetchBalanceSheets(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("FetchBalanceSheets() error = %v", err)
+	}
+	if len(sheets) != 1 {
+		t.Fatalf("len(sheets) = %d, want 1", len(sheets))
+	}
+	if sheets[0].TotalAssets != 1000000000 {
+		t.Errorf("TotalAssets = %v, want 1000000000", sheets[0].TotalAssets)
+	}
+	if sheets[0].TotalEquity != 300000000 {
+		t.Errorf("TotalEquity = %v, want 300000000", sheets[0].TotalEquity)
+	}
+	if sheets[0].TotalDebt != 400000000 {
+		t.Errorf("TotalDebt = %v, want 400000000", sheets[0].TotalDebt)
+	}
+	if sheets[0].Ticker != "BBCA" {
+		t.Errorf("Ticker = %q, want BBCA", sheets[0].Ticker)
+	}
+}
+
+func TestFMPFetchCashFlowStatements(t *testing.T) {
+	resp := []cashFlowResponse{
+		{
+			CalendarYear:      "2024",
+			Period:            "FY",
+			OperatingCashFlow: 20000000,
+			FreeCashFlow:      15000000,
+			DividendsPaid:     5000000,
+		},
+	}
+
+	f := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/cash-flow-statement/BBCA.JK" {
+			t.Errorf("request path = %q, want /cash-flow-statement/BBCA.JK", got)
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	stmts, err := f.FetchCashFlowStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("FetchCashFlowStatements() error = %v", err)
+	}
+	if len(stmts) != 1 {
+		t.Fatalf("len(stmts) = %d, want 1", len(stmts))
+	}
+	if stmts[0].OperatingCashFlow != 20000000 {
+		t.Errorf("OperatingCashFlow = %v, want 20000000", stmts[0].OperatingCashFlow)
+	}
+	if stmts[0].FreeCashFlow != 15000000 {
+		t.Errorf("FreeCashFlow = %v, want 15000000", stmts[0].FreeCashFlow)
+	}
+}
+
+func TestFMPHTTPErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErr    error
+	}{
+		{"forbidden returns ErrInvalidKey", http.StatusForbidden, financials.ErrInvalidKey},
+		{"rate limited returns ErrRateLimited", http.StatusTooManyRequests, financials.ErrRateLimited},
+		{"server error returns ErrSourceDown", http.StatusInternalServerError, financials.ErrSourceDown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			})
+
+			_, err := f.FetchIncomeStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestFMPEmptyResponse(t *testing.T) {
+	f := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]incomeStatementResponse{})
+	})
+
+	_, err := f.FetchIncomeStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err == nil {
+		t.Fatal("expected error for empty response, got nil")
+	}
+}
+
+func TestFMPTickerWithJKSuffix(t *testing.T) {
+	f := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/income-statement/BBCA.JK" {
+			t.Errorf("request path = %q, want /income-statement/BBCA.JK", got)
+		}
+		_ = json.NewEncoder(w).Encode([]incomeStatementResponse{
+			{CalendarYear: "2024", Period: "FY", Revenue: 1000},
+		})
+	})
+
+	// Passing ticker with .JK suffix should not double-append
+	_, err := f.FetchIncomeStatements(context.Background(), "BBCA.JK", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("FetchIncomeStatements() error = %v", err)
+	}
+}
+
+func TestParseFMPPeriod(t *testing.T) {
+	tests := []struct {
+		calYear string
+		period  string
+		wantY   int
+		wantQ   int
+	}{
+		{"2024", "FY", 2024, 0},
+		{"2024", "Q1", 2024, 1},
+		{"2023", "Q4", 2023, 4},
+		{"", "FY", 0, 0},
+	}
+
+	for _, tt := range tests {
+		y, q := parseFMPPeriod(tt.calYear, tt.period)
+		if y != tt.wantY || q != tt.wantQ {
+			t.Errorf("parseFMPPeriod(%q, %q) = (%d, %d), want (%d, %d)",
+				tt.calYear, tt.period, y, q, tt.wantY, tt.wantQ)
+		}
+	}
+}

--- a/backend/infra/fmp/response.go
+++ b/backend/infra/fmp/response.go
@@ -1,0 +1,57 @@
+package fmp
+
+// incomeStatementResponse maps the FMP income-statement JSON.
+type incomeStatementResponse struct {
+	Date              string  `json:"date"`
+	Symbol            string  `json:"symbol"`
+	CalendarYear      string  `json:"calendarYear"`
+	Period            string  `json:"period"`
+	Revenue           float64 `json:"revenue"`
+	CostOfRevenue     float64 `json:"costOfRevenue"`
+	GrossProfit       float64 `json:"grossProfit"`
+	OperatingExpenses float64 `json:"operatingExpenses"`
+	OperatingIncome   float64 `json:"operatingIncome"`
+	NetIncome         float64 `json:"netIncome"`
+	EPS               float64 `json:"eps"`
+	EPSDiluted        float64 `json:"epsdiluted"`
+	EBITDA            float64 `json:"ebitda"`
+	InterestExpense   float64 `json:"interestExpense"`
+	IncomeTaxExpense  float64 `json:"incomeTaxExpense"`
+}
+
+// balanceSheetResponse maps the FMP balance-sheet-statement JSON.
+type balanceSheetResponse struct {
+	Date                         string  `json:"date"`
+	Symbol                       string  `json:"symbol"`
+	CalendarYear                 string  `json:"calendarYear"`
+	Period                       string  `json:"period"`
+	TotalAssets                  float64 `json:"totalAssets"`
+	TotalCurrentAssets           float64 `json:"totalCurrentAssets"`
+	CashAndCashEquivalents       float64 `json:"cashAndCashEquivalents"`
+	NetReceivables               float64 `json:"netReceivables"`
+	Inventory                    float64 `json:"inventory"`
+	IntangibleAssets             float64 `json:"intangibleAssets"`
+	TotalLiabilities             float64 `json:"totalLiabilities"`
+	TotalCurrentLiabilities      float64 `json:"totalCurrentLiabilities"`
+	LongTermDebt                 float64 `json:"longTermDebt"`
+	TotalDebt                    float64 `json:"totalDebt"`
+	TotalStockholdersEquity      float64 `json:"totalStockholdersEquity"`
+	RetainedEarnings             float64 `json:"retainedEarnings"`
+	CommonStockSharesOutstanding float64 `json:"commonStockSharesOutstanding"`
+}
+
+// cashFlowResponse maps the FMP cash-flow-statement JSON.
+type cashFlowResponse struct {
+	Date                                     string  `json:"date"`
+	Symbol                                   string  `json:"symbol"`
+	CalendarYear                             string  `json:"calendarYear"`
+	Period                                   string  `json:"period"`
+	OperatingCashFlow                        float64 `json:"operatingCashFlow"`
+	CapitalExpenditure                       float64 `json:"capitalExpenditure"`
+	FreeCashFlow                             float64 `json:"freeCashFlow"`
+	DividendsPaid                            float64 `json:"dividendsPaid"`
+	DebtRepayment                            float64 `json:"debtRepayment"`
+	NetCashUsedForInvestingActivites         float64 `json:"netCashUsedForInvestingActivites"`
+	NetCashUsedProvidedByFinancingActivities float64 `json:"netCashUsedProvidedByFinancingActivities"`
+	NetChangeInCash                          float64 `json:"netChangeInCash"`
+}

--- a/backend/infra/fsprovider/registry.go
+++ b/backend/infra/fsprovider/registry.go
@@ -1,0 +1,244 @@
+package fsprovider
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/lugassawan/panen/backend/domain/financials"
+	domainProvider "github.com/lugassawan/panen/backend/domain/provider"
+	"github.com/lugassawan/panen/backend/infra/applog"
+)
+
+const (
+	sourceRegistry    = "fs-registry"
+	healthCheckTicker = "BBCA"
+)
+
+// entry holds a provider alongside its registration metadata.
+type entry struct {
+	provider  financials.FinancialStatementProvider
+	priority  int
+	status    domainProvider.Status
+	lastCheck time.Time
+	lastError string
+	enabled   bool
+}
+
+// Registry manages multiple FinancialStatementProvider implementations with
+// priority ordering and automatic fallback.
+type Registry struct {
+	mu      sync.RWMutex
+	entries []entry
+}
+
+// Compile-time checks.
+var (
+	_ financials.FinancialStatementProvider = (*Registry)(nil)
+	_ financials.Registry                   = (*Registry)(nil)
+)
+
+// NewRegistry creates an empty financial statement provider registry.
+func NewRegistry() *Registry {
+	return &Registry{}
+}
+
+// Register adds a provider with the given priority (lower = higher priority).
+func (r *Registry) Register(p financials.FinancialStatementProvider, priority int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.entries = append(r.entries, entry{
+		provider: p,
+		priority: priority,
+		status:   domainProvider.StatusUnknown,
+		enabled:  true,
+	})
+	sort.Slice(r.entries, func(i, j int) bool {
+		return r.entries[i].priority < r.entries[j].priority
+	})
+}
+
+// Source returns the source identifier of the primary provider.
+func (r *Registry) Source() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, e := range r.entries {
+		if e.enabled {
+			return e.provider.Source()
+		}
+	}
+	return sourceRegistry
+}
+
+// List returns metadata about all registered providers.
+func (r *Registry) List() []domainProvider.Info {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	infos := make([]domainProvider.Info, len(r.entries))
+	for i, e := range r.entries {
+		infos[i] = domainProvider.Info{
+			Name:      e.provider.Source(),
+			Priority:  e.priority,
+			Status:    e.status,
+			LastCheck: e.lastCheck,
+			LastError: e.lastError,
+			Enabled:   e.enabled,
+		}
+	}
+	return infos
+}
+
+// SetEnabled enables or disables a provider by name.
+func (r *Registry) SetEnabled(name string, enabled bool) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	idx := -1
+	enabledCount := 0
+	for i, e := range r.entries {
+		if e.provider.Source() == name {
+			idx = i
+		}
+		if e.enabled {
+			enabledCount++
+		}
+	}
+
+	if idx < 0 {
+		return false
+	}
+
+	if !enabled && enabledCount <= 1 && r.entries[idx].enabled {
+		return false
+	}
+
+	r.entries[idx].enabled = enabled
+
+	if !enabled {
+		r.entries[idx].status = domainProvider.StatusUnknown
+		r.entries[idx].lastError = ""
+	}
+
+	return true
+}
+
+// FetchIncomeStatements tries each enabled provider in priority order until one succeeds.
+func (r *Registry) FetchIncomeStatements(
+	ctx context.Context,
+	ticker string,
+	period financials.PeriodType,
+) ([]financials.IncomeStatement, error) {
+	var lastErr error
+	for _, e := range r.enabledEntries() {
+		result, err := e.provider.FetchIncomeStatements(ctx, ticker, period)
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		r.logFallback("FetchIncomeStatements", e.provider.Source(), ticker, err)
+	}
+	if lastErr == nil {
+		return nil, financials.ErrNoStatements
+	}
+	return nil, lastErr
+}
+
+// FetchBalanceSheets tries each enabled provider in priority order until one succeeds.
+func (r *Registry) FetchBalanceSheets(
+	ctx context.Context,
+	ticker string,
+	period financials.PeriodType,
+) ([]financials.BalanceSheet, error) {
+	var lastErr error
+	for _, e := range r.enabledEntries() {
+		result, err := e.provider.FetchBalanceSheets(ctx, ticker, period)
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		r.logFallback("FetchBalanceSheets", e.provider.Source(), ticker, err)
+	}
+	if lastErr == nil {
+		return nil, financials.ErrNoStatements
+	}
+	return nil, lastErr
+}
+
+// FetchCashFlowStatements tries each enabled provider in priority order until one succeeds.
+func (r *Registry) FetchCashFlowStatements(
+	ctx context.Context,
+	ticker string,
+	period financials.PeriodType,
+) ([]financials.CashFlowStatement, error) {
+	var lastErr error
+	for _, e := range r.enabledEntries() {
+		result, err := e.provider.FetchCashFlowStatements(ctx, ticker, period)
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		r.logFallback("FetchCashFlowStatements", e.provider.Source(), ticker, err)
+	}
+	if lastErr == nil {
+		return nil, financials.ErrNoStatements
+	}
+	return nil, lastErr
+}
+
+// HealthCheckAll runs health checks on all registered providers.
+func (r *Registry) HealthCheckAll(ctx context.Context) {
+	snapshot := r.enabledEntries()
+
+	for _, e := range snapshot {
+		status := domainProvider.StatusHealthy
+		var errMsg string
+
+		_, err := e.provider.FetchIncomeStatements(ctx, healthCheckTicker, financials.PeriodAnnual)
+		if err != nil {
+			status = domainProvider.StatusDown
+			errMsg = err.Error()
+		}
+
+		r.updateStatus(e.provider.Source(), status, errMsg)
+	}
+}
+
+func (r *Registry) updateStatus(name string, status domainProvider.Status, errMsg string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := time.Now().UTC()
+	for i, e := range r.entries {
+		if e.provider.Source() == name {
+			r.entries[i].status = status
+			r.entries[i].lastCheck = now
+			r.entries[i].lastError = errMsg
+			return
+		}
+	}
+}
+
+func (r *Registry) enabledEntries() []entry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var enabled []entry
+	for _, e := range r.entries {
+		if e.enabled {
+			enabled = append(enabled, e)
+		}
+	}
+	return enabled
+}
+
+func (r *Registry) logFallback(method, source, ticker string, err error) {
+	applog.Warn("fs provider fallback", err, applog.Fields{
+		"method":   method,
+		"provider": source,
+		"ticker":   ticker,
+	})
+}

--- a/backend/infra/fsprovider/registry_test.go
+++ b/backend/infra/fsprovider/registry_test.go
@@ -1,0 +1,214 @@
+package fsprovider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/lugassawan/panen/backend/domain/financials"
+	domainProvider "github.com/lugassawan/panen/backend/domain/provider"
+)
+
+// stubProvider is a test double for FinancialStatementProvider.
+type stubProvider struct {
+	source        string
+	incomeStmts   []financials.IncomeStatement
+	balanceSheets []financials.BalanceSheet
+	cashFlows     []financials.CashFlowStatement
+	err           error
+}
+
+func (s *stubProvider) Source() string { return s.source }
+
+func (s *stubProvider) FetchIncomeStatements(
+	_ context.Context, _ string, _ financials.PeriodType,
+) ([]financials.IncomeStatement, error) {
+	return s.incomeStmts, s.err
+}
+
+func (s *stubProvider) FetchBalanceSheets(
+	_ context.Context, _ string, _ financials.PeriodType,
+) ([]financials.BalanceSheet, error) {
+	return s.balanceSheets, s.err
+}
+
+func (s *stubProvider) FetchCashFlowStatements(
+	_ context.Context, _ string, _ financials.PeriodType,
+) ([]financials.CashFlowStatement, error) {
+	return s.cashFlows, s.err
+}
+
+func TestRegistryFallback(t *testing.T) {
+	primary := &stubProvider{source: "fmp", err: errors.New("fmp down")}
+	secondary := &stubProvider{
+		source:      "sectors",
+		incomeStmts: []financials.IncomeStatement{{Ticker: "BBCA", Source: "sectors"}},
+	}
+
+	reg := NewRegistry()
+	reg.Register(primary, 1)
+	reg.Register(secondary, 2)
+
+	stmts, err := reg.FetchIncomeStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("FetchIncomeStatements() error = %v", err)
+	}
+	if len(stmts) != 1 || stmts[0].Source != "sectors" {
+		t.Errorf("expected fallback to sectors, got %v", stmts)
+	}
+}
+
+func TestRegistryPrimarySuccess(t *testing.T) {
+	primary := &stubProvider{
+		source:      "fmp",
+		incomeStmts: []financials.IncomeStatement{{Ticker: "BBCA", Source: "fmp"}},
+	}
+	secondary := &stubProvider{source: "sectors", err: errors.New("should not be called")}
+
+	reg := NewRegistry()
+	reg.Register(primary, 1)
+	reg.Register(secondary, 2)
+
+	stmts, err := reg.FetchIncomeStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("FetchIncomeStatements() error = %v", err)
+	}
+	if stmts[0].Source != "fmp" {
+		t.Errorf("expected primary (fmp), got %q", stmts[0].Source)
+	}
+}
+
+func TestRegistryAllDown(t *testing.T) {
+	primary := &stubProvider{source: "fmp", err: errors.New("fmp down")}
+	secondary := &stubProvider{source: "sectors", err: errors.New("sectors down")}
+
+	reg := NewRegistry()
+	reg.Register(primary, 1)
+	reg.Register(secondary, 2)
+
+	_, err := reg.FetchIncomeStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err == nil {
+		t.Fatal("expected error when all providers are down")
+	}
+}
+
+func TestRegistryNoProviders(t *testing.T) {
+	reg := NewRegistry()
+
+	_, err := reg.FetchIncomeStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+	if !errors.Is(err, financials.ErrNoStatements) {
+		t.Errorf("expected ErrNoStatements, got %v", err)
+	}
+}
+
+func TestRegistrySource(t *testing.T) {
+	reg := NewRegistry()
+	if got := reg.Source(); got != "fs-registry" {
+		t.Errorf("empty registry Source() = %q, want fs-registry", got)
+	}
+
+	reg.Register(&stubProvider{source: "fmp"}, 1)
+	if got := reg.Source(); got != "fmp" {
+		t.Errorf("Source() = %q, want fmp", got)
+	}
+}
+
+func TestRegistrySetEnabled(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(&stubProvider{source: "fmp"}, 1)
+	reg.Register(&stubProvider{source: "sectors"}, 2)
+
+	// Disable secondary
+	if !reg.SetEnabled("sectors", false) {
+		t.Error("SetEnabled(sectors, false) returned false")
+	}
+
+	// Cannot disable last enabled
+	if reg.SetEnabled("fmp", false) {
+		t.Error("SetEnabled(fmp, false) should return false when it's the last enabled")
+	}
+
+	// Non-existent provider
+	if reg.SetEnabled("nonexist", false) {
+		t.Error("SetEnabled(nonexist) should return false")
+	}
+}
+
+func TestRegistryList(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(&stubProvider{source: "fmp"}, 1)
+	reg.Register(&stubProvider{source: "sectors"}, 2)
+
+	infos := reg.List()
+	if len(infos) != 2 {
+		t.Fatalf("len(List()) = %d, want 2", len(infos))
+	}
+	if infos[0].Name != "fmp" || infos[0].Priority != 1 {
+		t.Errorf("infos[0] = %+v, want fmp/1", infos[0])
+	}
+	if infos[1].Name != "sectors" || infos[1].Priority != 2 {
+		t.Errorf("infos[1] = %+v, want sectors/2", infos[1])
+	}
+}
+
+func TestRegistryHealthCheckAll(t *testing.T) {
+	healthy := &stubProvider{
+		source:      "fmp",
+		incomeStmts: []financials.IncomeStatement{{Ticker: "BBCA"}},
+	}
+	down := &stubProvider{source: "sectors", err: errors.New("down")}
+
+	reg := NewRegistry()
+	reg.Register(healthy, 1)
+	reg.Register(down, 2)
+
+	reg.HealthCheckAll(context.Background())
+
+	infos := reg.List()
+	if infos[0].Status != domainProvider.StatusHealthy {
+		t.Errorf("fmp status = %q, want healthy", infos[0].Status)
+	}
+	if infos[1].Status != domainProvider.StatusDown {
+		t.Errorf("sectors status = %q, want down", infos[1].Status)
+	}
+}
+
+func TestRegistryFetchBalanceSheetsFallback(t *testing.T) {
+	primary := &stubProvider{source: "fmp", err: errors.New("fmp down")}
+	secondary := &stubProvider{
+		source:        "sectors",
+		balanceSheets: []financials.BalanceSheet{{Ticker: "BBCA", Source: "sectors"}},
+	}
+
+	reg := NewRegistry()
+	reg.Register(primary, 1)
+	reg.Register(secondary, 2)
+
+	sheets, err := reg.FetchBalanceSheets(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("FetchBalanceSheets() error = %v", err)
+	}
+	if len(sheets) != 1 || sheets[0].Source != "sectors" {
+		t.Errorf("expected fallback to sectors, got %v", sheets)
+	}
+}
+
+func TestRegistryFetchCashFlowStatementsFallback(t *testing.T) {
+	primary := &stubProvider{source: "fmp", err: errors.New("fmp down")}
+	secondary := &stubProvider{
+		source:    "sectors",
+		cashFlows: []financials.CashFlowStatement{{Ticker: "BBCA", Source: "sectors"}},
+	}
+
+	reg := NewRegistry()
+	reg.Register(primary, 1)
+	reg.Register(secondary, 2)
+
+	stmts, err := reg.FetchCashFlowStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("FetchCashFlowStatements() error = %v", err)
+	}
+	if len(stmts) != 1 || stmts[0].Source != "sectors" {
+		t.Errorf("expected fallback to sectors, got %v", stmts)
+	}
+}

--- a/backend/infra/sectorsapp/response.go
+++ b/backend/infra/sectorsapp/response.go
@@ -1,0 +1,47 @@
+package sectorsapp
+
+// financialReportResponse maps the SectorsApp financial report JSON.
+// SectorsApp returns a unified report per period containing all three statements.
+type financialReportResponse struct {
+	Symbol  string `json:"symbol"`
+	Year    int    `json:"year"`
+	Quarter int    `json:"quarter"` // 0 for annual
+
+	// Income statement fields
+	Revenue           float64 `json:"revenue"`
+	CostOfRevenue     float64 `json:"cost_of_revenue"`
+	GrossProfit       float64 `json:"gross_profit"`
+	OperatingExpenses float64 `json:"operating_expenses"`
+	OperatingIncome   float64 `json:"operating_income"`
+	NetIncome         float64 `json:"net_income"`
+	EPS               float64 `json:"earnings_per_share"`
+	EPSDiluted        float64 `json:"earnings_per_share_diluted"`
+	EBITDA            float64 `json:"ebitda"`
+	InterestExpense   float64 `json:"interest_expense"`
+	IncomeTaxExpense  float64 `json:"income_tax_expense"`
+
+	// Balance sheet fields
+	TotalAssets        float64 `json:"total_assets"`
+	TotalCurrentAssets float64 `json:"total_current_assets"`
+	CashAndEquivalents float64 `json:"cash_and_equivalents"`
+	Receivables        float64 `json:"receivables"`
+	Inventory          float64 `json:"inventory"`
+	IntangibleAssets   float64 `json:"intangible_assets"`
+	TotalLiabilities   float64 `json:"total_liabilities"`
+	TotalCurrentLiab   float64 `json:"total_current_liabilities"`
+	LongTermDebt       float64 `json:"long_term_debt"`
+	TotalDebt          float64 `json:"total_debt"`
+	TotalEquity        float64 `json:"total_equity"`
+	RetainedEarnings   float64 `json:"retained_earnings"`
+	SharesOutstanding  float64 `json:"shares_outstanding"`
+
+	// Cash flow fields
+	OperatingCashFlow  float64 `json:"operating_cash_flow"`
+	CapitalExpenditure float64 `json:"capital_expenditure"`
+	FreeCashFlow       float64 `json:"free_cash_flow"`
+	DividendsPaid      float64 `json:"dividends_paid"`
+	NetBorrowings      float64 `json:"net_borrowings"`
+	InvestingCashFlow  float64 `json:"investing_cash_flow"`
+	FinancingCashFlow  float64 `json:"financing_cash_flow"`
+	NetChangeInCash    float64 `json:"net_change_in_cash"`
+}

--- a/backend/infra/sectorsapp/sectorsapp.go
+++ b/backend/infra/sectorsapp/sectorsapp.go
@@ -1,0 +1,243 @@
+package sectorsapp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/lugassawan/panen/backend/domain/financials"
+)
+
+const (
+	defaultBaseURL  = "https://api.sectors.app/v1"
+	maxResponseSize = 5 << 20 // 5 MB
+	sourceSectors   = "sectors"
+)
+
+// SectorsApp fetches financial statement data from the Sectors.app API.
+type SectorsApp struct {
+	client  *http.Client
+	limiter *rate.Limiter
+	baseURL string
+	apiKey  string
+}
+
+// Option configures the SectorsApp provider.
+type Option func(*SectorsApp)
+
+// WithBaseURL overrides the base URL (useful for tests).
+func WithBaseURL(u string) Option {
+	return func(s *SectorsApp) { s.baseURL = u }
+}
+
+// WithRateLimit sets custom rate limiter parameters.
+func WithRateLimit(rps float64, burst int) Option {
+	return func(s *SectorsApp) { s.limiter = rate.NewLimiter(rate.Limit(rps), burst) }
+}
+
+// WithHTTPClient overrides the HTTP client (useful for tests).
+func WithHTTPClient(c *http.Client) Option {
+	return func(s *SectorsApp) { s.client = c }
+}
+
+// NewSectorsApp creates a SectorsApp provider with the given API key and options.
+func NewSectorsApp(apiKey string, opts ...Option) *SectorsApp {
+	s := &SectorsApp{
+		limiter: rate.NewLimiter(2, 5),
+		baseURL: defaultBaseURL,
+		apiKey:  apiKey,
+	}
+	for _, o := range opts {
+		o(s)
+	}
+	if s.client == nil {
+		s.client = &http.Client{}
+	}
+	return s
+}
+
+// Source returns the provider identifier.
+func (s *SectorsApp) Source() string { return sourceSectors }
+
+// FetchIncomeStatements returns income statements for a ticker and period type.
+func (s *SectorsApp) FetchIncomeStatements(
+	ctx context.Context,
+	ticker string,
+	period financials.PeriodType,
+) ([]financials.IncomeStatement, error) {
+	reports, err := s.fetchReports(ctx, ticker, period)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	stmts := make([]financials.IncomeStatement, len(reports))
+	for i, r := range reports {
+		stmts[i] = financials.IncomeStatement{
+			Ticker:            ticker,
+			Source:            sourceSectors,
+			FiscalYear:        r.Year,
+			Quarter:           r.Quarter,
+			Period:            period,
+			FetchedAt:         now,
+			Revenue:           r.Revenue,
+			CostOfRevenue:     r.CostOfRevenue,
+			GrossProfit:       r.GrossProfit,
+			OperatingExpenses: r.OperatingExpenses,
+			OperatingIncome:   r.OperatingIncome,
+			NetIncome:         r.NetIncome,
+			EPS:               r.EPS,
+			EPSDiluted:        r.EPSDiluted,
+			EBITDA:            r.EBITDA,
+			InterestExpense:   r.InterestExpense,
+			IncomeTaxExpense:  r.IncomeTaxExpense,
+		}
+	}
+	return stmts, nil
+}
+
+// FetchBalanceSheets returns balance sheets for a ticker and period type.
+func (s *SectorsApp) FetchBalanceSheets(
+	ctx context.Context,
+	ticker string,
+	period financials.PeriodType,
+) ([]financials.BalanceSheet, error) {
+	reports, err := s.fetchReports(ctx, ticker, period)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	sheets := make([]financials.BalanceSheet, len(reports))
+	for i, r := range reports {
+		sheets[i] = financials.BalanceSheet{
+			Ticker:             ticker,
+			Source:             sourceSectors,
+			FiscalYear:         r.Year,
+			Quarter:            r.Quarter,
+			Period:             period,
+			FetchedAt:          now,
+			TotalAssets:        r.TotalAssets,
+			TotalCurrentAssets: r.TotalCurrentAssets,
+			CashAndEquivalents: r.CashAndEquivalents,
+			Receivables:        r.Receivables,
+			Inventory:          r.Inventory,
+			IntangibleAssets:   r.IntangibleAssets,
+			TotalLiabilities:   r.TotalLiabilities,
+			TotalCurrentLiab:   r.TotalCurrentLiab,
+			LongTermDebt:       r.LongTermDebt,
+			TotalDebt:          r.TotalDebt,
+			TotalEquity:        r.TotalEquity,
+			RetainedEarnings:   r.RetainedEarnings,
+			SharesOutstanding:  r.SharesOutstanding,
+		}
+	}
+	return sheets, nil
+}
+
+// FetchCashFlowStatements returns cash flow statements for a ticker and period type.
+func (s *SectorsApp) FetchCashFlowStatements(
+	ctx context.Context,
+	ticker string,
+	period financials.PeriodType,
+) ([]financials.CashFlowStatement, error) {
+	reports, err := s.fetchReports(ctx, ticker, period)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	stmts := make([]financials.CashFlowStatement, len(reports))
+	for i, r := range reports {
+		stmts[i] = financials.CashFlowStatement{
+			Ticker:             ticker,
+			Source:             sourceSectors,
+			FiscalYear:         r.Year,
+			Quarter:            r.Quarter,
+			Period:             period,
+			FetchedAt:          now,
+			OperatingCashFlow:  r.OperatingCashFlow,
+			CapitalExpenditure: r.CapitalExpenditure,
+			FreeCashFlow:       r.FreeCashFlow,
+			DividendsPaid:      r.DividendsPaid,
+			NetBorrowings:      r.NetBorrowings,
+			InvestingCashFlow:  r.InvestingCashFlow,
+			FinancingCashFlow:  r.FinancingCashFlow,
+			NetChangeInCash:    r.NetChangeInCash,
+		}
+	}
+	return stmts, nil
+}
+
+func (s *SectorsApp) fetchReports(
+	ctx context.Context,
+	ticker string,
+	period financials.PeriodType,
+) ([]financialReportResponse, error) {
+	reqURL := fmt.Sprintf("%s/company/financials/%s/?period=%s", s.baseURL, ticker, string(period))
+
+	body, err := s.doGet(ctx, reqURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var reports []financialReportResponse
+	if err := json.Unmarshal(body, &reports); err != nil {
+		return nil, fmt.Errorf("%w: malformed financial report response", financials.ErrNoStatements)
+	}
+
+	if len(reports) == 0 {
+		return nil, fmt.Errorf("%w: empty financial report result", financials.ErrNoStatements)
+	}
+
+	return reports, nil
+}
+
+func (s *SectorsApp) doGet(ctx context.Context, reqURL string) ([]byte, error) {
+	if err := s.limiter.Wait(ctx); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.apiKey)
+
+	resp, err := s.client.Do(req) //nolint:gosec // URL is constructed from controlled baseURL + ticker
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if err := mapHTTPError(resp.StatusCode); err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func mapHTTPError(code int) error {
+	switch {
+	case code == http.StatusOK:
+		return nil
+	case code == http.StatusUnauthorized || code == http.StatusForbidden:
+		return financials.ErrInvalidKey
+	case code == http.StatusTooManyRequests:
+		return financials.ErrRateLimited
+	case code >= 500:
+		return financials.ErrSourceDown
+	default:
+		return fmt.Errorf("unexpected HTTP status %d", code)
+	}
+}

--- a/backend/infra/sectorsapp/sectorsapp_test.go
+++ b/backend/infra/sectorsapp/sectorsapp_test.go
@@ -1,0 +1,149 @@
+package sectorsapp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lugassawan/panen/backend/domain/financials"
+)
+
+func setupTestServer(t *testing.T, handler http.HandlerFunc) *SectorsApp {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return NewSectorsApp("test-key", WithBaseURL(server.URL), WithHTTPClient(server.Client()))
+}
+
+func TestSectorsAppSource(t *testing.T) {
+	s := NewSectorsApp("key")
+	if got := s.Source(); got != "sectors" {
+		t.Errorf("Source() = %q, want %q", got, "sectors")
+	}
+}
+
+func TestSectorsAppFetchIncomeStatements(t *testing.T) {
+	reports := []financialReportResponse{
+		{
+			Symbol:    "BBCA",
+			Year:      2024,
+			Quarter:   0,
+			Revenue:   50000000,
+			NetIncome: 15000000,
+			EPS:       500,
+		},
+		{
+			Symbol:  "BBCA",
+			Year:    2023,
+			Quarter: 0,
+			Revenue: 45000000,
+		},
+	}
+
+	s := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/company/financials/BBCA/" {
+			t.Errorf("request path = %q, want /company/financials/BBCA/", got)
+		}
+		if got := r.URL.Query().Get("period"); got != "annual" {
+			t.Errorf("period = %q, want annual", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+		_ = json.NewEncoder(w).Encode(reports)
+	})
+
+	stmts, err := s.FetchIncomeStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("FetchIncomeStatements() error = %v", err)
+	}
+	if len(stmts) != 2 {
+		t.Fatalf("len(stmts) = %d, want 2", len(stmts))
+	}
+	if stmts[0].Revenue != 50000000 {
+		t.Errorf("stmts[0].Revenue = %v, want 50000000", stmts[0].Revenue)
+	}
+	if stmts[0].Source != "sectors" {
+		t.Errorf("stmts[0].Source = %q, want sectors", stmts[0].Source)
+	}
+}
+
+func TestSectorsAppFetchBalanceSheets(t *testing.T) {
+	reports := []financialReportResponse{
+		{Year: 2024, TotalAssets: 1000000000, TotalEquity: 300000000},
+	}
+
+	s := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(reports)
+	})
+
+	sheets, err := s.FetchBalanceSheets(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("FetchBalanceSheets() error = %v", err)
+	}
+	if len(sheets) != 1 {
+		t.Fatalf("len(sheets) = %d, want 1", len(sheets))
+	}
+	if sheets[0].TotalAssets != 1000000000 {
+		t.Errorf("TotalAssets = %v, want 1000000000", sheets[0].TotalAssets)
+	}
+}
+
+func TestSectorsAppFetchCashFlowStatements(t *testing.T) {
+	reports := []financialReportResponse{
+		{Year: 2024, OperatingCashFlow: 20000000, FreeCashFlow: 15000000},
+	}
+
+	s := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(reports)
+	})
+
+	stmts, err := s.FetchCashFlowStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("FetchCashFlowStatements() error = %v", err)
+	}
+	if len(stmts) != 1 {
+		t.Fatalf("len(stmts) = %d, want 1", len(stmts))
+	}
+	if stmts[0].FreeCashFlow != 15000000 {
+		t.Errorf("FreeCashFlow = %v, want 15000000", stmts[0].FreeCashFlow)
+	}
+}
+
+func TestSectorsAppHTTPErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"unauthorized", http.StatusUnauthorized},
+		{"forbidden", http.StatusForbidden},
+		{"rate limited", http.StatusTooManyRequests},
+		{"server error", http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			})
+
+			_, err := s.FetchIncomeStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestSectorsAppEmptyResponse(t *testing.T) {
+	s := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]financialReportResponse{})
+	})
+
+	_, err := s.FetchIncomeStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err == nil {
+		t.Fatal("expected error for empty response, got nil")
+	}
+}

--- a/backend/presenter/dto.go
+++ b/backend/presenter/dto.go
@@ -487,6 +487,12 @@ type TransactionListResponse struct {
 	Summary TransactionSummaryResponse  `json:"summary"`
 }
 
+// APIKeyStatusResponse is the frontend-facing response for API key configuration status.
+type APIKeyStatusResponse struct {
+	FMPConfigured     bool `json:"fmpConfigured"`
+	SectorsConfigured bool `json:"sectorsConfigured"`
+}
+
 // ProviderStatusResponse is the frontend-facing response for a data provider's status.
 type ProviderStatusResponse struct {
 	Name      string `json:"name"`

--- a/backend/presenter/settings.go
+++ b/backend/presenter/settings.go
@@ -1,0 +1,62 @@
+package presenter
+
+import (
+	"context"
+
+	"github.com/lugassawan/panen/backend/domain/settings"
+)
+
+const (
+	settingFMPAPIKey     = "fmp_api_key"     //nolint:gosec // settings key name, not a credential
+	settingSectorsAPIKey = "sectors_api_key" //nolint:gosec // settings key name, not a credential
+)
+
+// SettingsHandler handles API key settings requests from the frontend.
+type SettingsHandler struct {
+	ctx      context.Context
+	settings settings.Repository
+}
+
+// Bind wires the handler to its dependencies.
+func (h *SettingsHandler) Bind(ctx context.Context, settings settings.Repository) {
+	h.ctx = ctx
+	h.settings = settings
+}
+
+// GetAPIKeyStatus returns which API keys are configured (never exposes raw keys).
+func (h *SettingsHandler) GetAPIKeyStatus() (*APIKeyStatusResponse, error) {
+	fmpKey, err := h.settings.GetSetting(h.ctx, settingFMPAPIKey)
+	if err != nil {
+		return nil, err
+	}
+
+	sectorsKey, err := h.settings.GetSetting(h.ctx, settingSectorsAPIKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &APIKeyStatusResponse{
+		FMPConfigured:     fmpKey != "",
+		SectorsConfigured: sectorsKey != "",
+	}, nil
+}
+
+// SetFMPAPIKey stores the FMP API key.
+func (h *SettingsHandler) SetFMPAPIKey(key string) error {
+	return h.settings.SetSetting(h.ctx, settingFMPAPIKey, key)
+}
+
+// SetSectorsAPIKey stores the Sectors.app API key.
+func (h *SettingsHandler) SetSectorsAPIKey(key string) error {
+	return h.settings.SetSetting(h.ctx, settingSectorsAPIKey, key)
+}
+
+// ClearFMPAPIKey removes the FMP API key.
+func (h *SettingsHandler) ClearFMPAPIKey() error {
+	return h.settings.SetSetting(h.ctx, settingFMPAPIKey, "")
+}
+
+// ClearSectorsAPIKey removes the Sectors.app API key.
+func (h *SettingsHandler) ClearSectorsAPIKey() error {
+	return h.settings.SetSetting(h.ctx, settingSectorsAPIKey, "")
+}

--- a/backend/usecase/financials.go
+++ b/backend/usecase/financials.go
@@ -1,0 +1,113 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"github.com/lugassawan/panen/backend/domain/financials"
+)
+
+const financialsCacheTTL = 24 * time.Hour
+
+// FinancialStatementsService handles on-demand fetching and caching of financial statements.
+type FinancialStatementsService struct {
+	incomeRepo   financials.IncomeStatementRepo
+	balanceRepo  financials.BalanceSheetRepo
+	cashFlowRepo financials.CashFlowStatementRepo
+	provider     financials.FinancialStatementProvider
+}
+
+// NewFinancialStatementsService creates a new FinancialStatementsService.
+func NewFinancialStatementsService(
+	incomeRepo financials.IncomeStatementRepo,
+	balanceRepo financials.BalanceSheetRepo,
+	cashFlowRepo financials.CashFlowStatementRepo,
+	provider financials.FinancialStatementProvider,
+) *FinancialStatementsService {
+	return &FinancialStatementsService{
+		incomeRepo:   incomeRepo,
+		balanceRepo:  balanceRepo,
+		cashFlowRepo: cashFlowRepo,
+		provider:     provider,
+	}
+}
+
+// GetIncomeStatements returns cached income statements, refreshing from the provider if stale.
+func (s *FinancialStatementsService) GetIncomeStatements(
+	ctx context.Context,
+	ticker string,
+	period financials.PeriodType,
+) ([]financials.IncomeStatement, error) {
+	latest, err := s.incomeRepo.LatestFetchedAt(ctx, ticker, s.provider.Source())
+	if err != nil {
+		return nil, err
+	}
+
+	if !isFinancialsFresh(latest) {
+		stmts, err := s.provider.FetchIncomeStatements(ctx, ticker, period)
+		if err != nil {
+			return nil, err
+		}
+		if err := s.incomeRepo.BulkUpsert(ctx, stmts); err != nil {
+			return nil, err
+		}
+	}
+
+	return s.incomeRepo.GetByTicker(ctx, ticker, s.provider.Source(), period)
+}
+
+// GetBalanceSheets returns cached balance sheets, refreshing from the provider if stale.
+func (s *FinancialStatementsService) GetBalanceSheets(
+	ctx context.Context,
+	ticker string,
+	period financials.PeriodType,
+) ([]financials.BalanceSheet, error) {
+	latest, err := s.balanceRepo.LatestFetchedAt(ctx, ticker, s.provider.Source())
+	if err != nil {
+		return nil, err
+	}
+
+	if !isFinancialsFresh(latest) {
+		sheets, err := s.provider.FetchBalanceSheets(ctx, ticker, period)
+		if err != nil {
+			return nil, err
+		}
+		if err := s.balanceRepo.BulkUpsert(ctx, sheets); err != nil {
+			return nil, err
+		}
+	}
+
+	return s.balanceRepo.GetByTicker(ctx, ticker, s.provider.Source(), period)
+}
+
+// GetCashFlowStatements returns cached cash flow statements, refreshing from the provider if stale.
+func (s *FinancialStatementsService) GetCashFlowStatements(
+	ctx context.Context,
+	ticker string,
+	period financials.PeriodType,
+) ([]financials.CashFlowStatement, error) {
+	latest, err := s.cashFlowRepo.LatestFetchedAt(ctx, ticker, s.provider.Source())
+	if err != nil {
+		return nil, err
+	}
+
+	if !isFinancialsFresh(latest) {
+		stmts, err := s.provider.FetchCashFlowStatements(ctx, ticker, period)
+		if err != nil {
+			return nil, err
+		}
+		if err := s.cashFlowRepo.BulkUpsert(ctx, stmts); err != nil {
+			return nil, err
+		}
+	}
+
+	return s.cashFlowRepo.GetByTicker(ctx, ticker, s.provider.Source(), period)
+}
+
+// isFinancialsFresh returns true if data was fetched within the last 24 hours.
+func isFinancialsFresh(latest time.Time) bool {
+	if latest.IsZero() {
+		return false
+	}
+	return time.Since(latest) < financialsCacheTTL
+}

--- a/backend/usecase/financials_test.go
+++ b/backend/usecase/financials_test.go
@@ -1,0 +1,242 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lugassawan/panen/backend/domain/financials"
+)
+
+// fsIncomeRepo is a test double for IncomeStatementRepo.
+type fsIncomeRepo struct {
+	stmts     []financials.IncomeStatement
+	fetchedAt time.Time
+	upserted  bool
+}
+
+func (m *fsIncomeRepo) BulkUpsert(_ context.Context, stmts []financials.IncomeStatement) error {
+	m.stmts = stmts
+	m.upserted = true
+	return nil
+}
+
+func (m *fsIncomeRepo) GetByTicker(
+	_ context.Context,
+	_, _ string,
+	_ financials.PeriodType,
+) ([]financials.IncomeStatement, error) {
+	return m.stmts, nil
+}
+
+func (m *fsIncomeRepo) LatestFetchedAt(_ context.Context, _, _ string) (time.Time, error) {
+	return m.fetchedAt, nil
+}
+
+// fsBalanceRepo is a test double for BalanceSheetRepo.
+type fsBalanceRepo struct {
+	sheets    []financials.BalanceSheet
+	fetchedAt time.Time
+	upserted  bool
+}
+
+func (m *fsBalanceRepo) BulkUpsert(_ context.Context, sheets []financials.BalanceSheet) error {
+	m.sheets = sheets
+	m.upserted = true
+	return nil
+}
+
+func (m *fsBalanceRepo) GetByTicker(
+	_ context.Context,
+	_, _ string,
+	_ financials.PeriodType,
+) ([]financials.BalanceSheet, error) {
+	return m.sheets, nil
+}
+
+func (m *fsBalanceRepo) LatestFetchedAt(_ context.Context, _, _ string) (time.Time, error) {
+	return m.fetchedAt, nil
+}
+
+// fsCashFlowRepo is a test double for CashFlowStatementRepo.
+type fsCashFlowRepo struct {
+	stmts     []financials.CashFlowStatement
+	fetchedAt time.Time
+	upserted  bool
+}
+
+func (m *fsCashFlowRepo) BulkUpsert(_ context.Context, stmts []financials.CashFlowStatement) error {
+	m.stmts = stmts
+	m.upserted = true
+	return nil
+}
+
+func (m *fsCashFlowRepo) GetByTicker(
+	_ context.Context,
+	_, _ string,
+	_ financials.PeriodType,
+) ([]financials.CashFlowStatement, error) {
+	return m.stmts, nil
+}
+
+func (m *fsCashFlowRepo) LatestFetchedAt(_ context.Context, _, _ string) (time.Time, error) {
+	return m.fetchedAt, nil
+}
+
+// mockFSProvider is a test double for FinancialStatementProvider.
+type mockFSProvider struct {
+	source      string
+	incomeStmts []financials.IncomeStatement
+	balSheets   []financials.BalanceSheet
+	cashFlows   []financials.CashFlowStatement
+	err         error
+	called      bool
+}
+
+func (m *mockFSProvider) Source() string { return m.source }
+
+func (m *mockFSProvider) FetchIncomeStatements(
+	_ context.Context, _ string, _ financials.PeriodType,
+) ([]financials.IncomeStatement, error) {
+	m.called = true
+	return m.incomeStmts, m.err
+}
+
+func (m *mockFSProvider) FetchBalanceSheets(
+	_ context.Context, _ string, _ financials.PeriodType,
+) ([]financials.BalanceSheet, error) {
+	m.called = true
+	return m.balSheets, m.err
+}
+
+func (m *mockFSProvider) FetchCashFlowStatements(
+	_ context.Context, _ string, _ financials.PeriodType,
+) ([]financials.CashFlowStatement, error) {
+	m.called = true
+	return m.cashFlows, m.err
+}
+
+func TestGetIncomeStatementsFetchesWhenStale(t *testing.T) {
+	repo := &fsIncomeRepo{}
+	provider := &mockFSProvider{
+		source:      "fmp",
+		incomeStmts: []financials.IncomeStatement{{Ticker: "BBCA", Revenue: 50000000}},
+	}
+
+	svc := NewFinancialStatementsService(repo, &fsBalanceRepo{}, &fsCashFlowRepo{}, provider)
+
+	stmts, err := svc.GetIncomeStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("GetIncomeStatements() error = %v", err)
+	}
+	if !provider.called {
+		t.Error("expected provider to be called for stale data")
+	}
+	if !repo.upserted {
+		t.Error("expected BulkUpsert to be called")
+	}
+	if len(stmts) != 1 || stmts[0].Revenue != 50000000 {
+		t.Errorf("unexpected stmts: %v", stmts)
+	}
+}
+
+func TestGetIncomeStatementsUsesCacheWhenFresh(t *testing.T) {
+	cached := []financials.IncomeStatement{{Ticker: "BBCA", Revenue: 45000000}}
+	repo := &fsIncomeRepo{
+		stmts:     cached,
+		fetchedAt: time.Now().UTC().Add(-1 * time.Hour), // 1h ago = fresh
+	}
+	provider := &mockFSProvider{source: "fmp"}
+
+	svc := NewFinancialStatementsService(repo, &fsBalanceRepo{}, &fsCashFlowRepo{}, provider)
+
+	stmts, err := svc.GetIncomeStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("GetIncomeStatements() error = %v", err)
+	}
+	if provider.called {
+		t.Error("expected provider NOT to be called for fresh data")
+	}
+	if len(stmts) != 1 || stmts[0].Revenue != 45000000 {
+		t.Errorf("unexpected stmts: %v", stmts)
+	}
+}
+
+func TestGetIncomeStatementsProviderError(t *testing.T) {
+	repo := &fsIncomeRepo{}
+	provider := &mockFSProvider{
+		source: "fmp",
+		err:    errors.New("api down"),
+	}
+
+	svc := NewFinancialStatementsService(repo, &fsBalanceRepo{}, &fsCashFlowRepo{}, provider)
+
+	_, err := svc.GetIncomeStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestGetBalanceSheetsFetchesWhenStale(t *testing.T) {
+	repo := &fsBalanceRepo{}
+	provider := &mockFSProvider{
+		source:    "fmp",
+		balSheets: []financials.BalanceSheet{{Ticker: "BBCA", TotalAssets: 1000000000}},
+	}
+
+	svc := NewFinancialStatementsService(&fsIncomeRepo{}, repo, &fsCashFlowRepo{}, provider)
+
+	sheets, err := svc.GetBalanceSheets(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("GetBalanceSheets() error = %v", err)
+	}
+	if !provider.called {
+		t.Error("expected provider to be called")
+	}
+	if len(sheets) != 1 || sheets[0].TotalAssets != 1000000000 {
+		t.Errorf("unexpected sheets: %v", sheets)
+	}
+}
+
+func TestGetCashFlowStatementsFetchesWhenStale(t *testing.T) {
+	repo := &fsCashFlowRepo{}
+	provider := &mockFSProvider{
+		source:    "fmp",
+		cashFlows: []financials.CashFlowStatement{{Ticker: "BBCA", FreeCashFlow: 15000000}},
+	}
+
+	svc := NewFinancialStatementsService(&fsIncomeRepo{}, &fsBalanceRepo{}, repo, provider)
+
+	stmts, err := svc.GetCashFlowStatements(context.Background(), "BBCA", financials.PeriodAnnual)
+	if err != nil {
+		t.Fatalf("GetCashFlowStatements() error = %v", err)
+	}
+	if !provider.called {
+		t.Error("expected provider to be called")
+	}
+	if len(stmts) != 1 || stmts[0].FreeCashFlow != 15000000 {
+		t.Errorf("unexpected stmts: %v", stmts)
+	}
+}
+
+func TestIsFinancialsFresh(t *testing.T) {
+	tests := []struct {
+		name   string
+		latest time.Time
+		want   bool
+	}{
+		{"zero time is stale", time.Time{}, false},
+		{"1 hour ago is fresh", time.Now().UTC().Add(-1 * time.Hour), true},
+		{"25 hours ago is stale", time.Now().UTC().Add(-25 * time.Hour), false},
+		{"23 hours ago is fresh", time.Now().UTC().Add(-23 * time.Hour), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isFinancialsFresh(tt.latest); got != tt.want {
+				t.Errorf("isFinancialsFresh(%v) = %v, want %v", tt.latest, got, tt.want)
+			}
+		})
+	}
+}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -179,7 +179,20 @@
     "providerUnknown": "Unknown",
     "providerCheckHealth": "Check Health",
     "providerCheckingHealth": "Checking...",
-    "providerCannotDisableLast": "Cannot disable the last provider"
+    "providerCannotDisableLast": "Cannot disable the last provider",
+    "apiKeys": "API Keys",
+    "apiKeysTooltip": "Configure API keys for financial statement providers (FMP, Sectors.app). Keys are stored locally and never sent to third parties.",
+    "fmpApiKey": "Financial Modeling Prep (FMP)",
+    "sectorsApiKey": "Sectors.app",
+    "apiKeyConfigured": "Configured",
+    "apiKeyNotConfigured": "Not configured",
+    "apiKeyPlaceholder": "Enter API key...",
+    "apiKeySave": "Save",
+    "apiKeyClear": "Clear",
+    "apiKeySaved": "API key saved. Restart app to apply.",
+    "apiKeyCleared": "API key cleared. Restart app to apply.",
+    "apiKeySaveError": "Failed to save API key: {error}",
+    "apiKeyRestartHint": "Changes take effect after restarting the app."
   },
   "format": {
     "justNow": "just now",

--- a/frontend/src/i18n/id.json
+++ b/frontend/src/i18n/id.json
@@ -179,7 +179,20 @@
     "providerUnknown": "Tidak Diketahui",
     "providerCheckHealth": "Periksa Kesehatan",
     "providerCheckingHealth": "Memeriksa...",
-    "providerCannotDisableLast": "Tidak dapat menonaktifkan penyedia terakhir"
+    "providerCannotDisableLast": "Tidak dapat menonaktifkan penyedia terakhir",
+    "apiKeys": "Kunci API",
+    "apiKeysTooltip": "Konfigurasikan kunci API untuk penyedia laporan keuangan (FMP, Sectors.app). Kunci disimpan secara lokal dan tidak pernah dikirim ke pihak ketiga.",
+    "fmpApiKey": "Financial Modeling Prep (FMP)",
+    "sectorsApiKey": "Sectors.app",
+    "apiKeyConfigured": "Terkonfigurasi",
+    "apiKeyNotConfigured": "Belum dikonfigurasi",
+    "apiKeyPlaceholder": "Masukkan kunci API...",
+    "apiKeySave": "Simpan",
+    "apiKeyClear": "Hapus",
+    "apiKeySaved": "Kunci API tersimpan. Mulai ulang aplikasi untuk menerapkan.",
+    "apiKeyCleared": "Kunci API dihapus. Mulai ulang aplikasi untuk menerapkan.",
+    "apiKeySaveError": "Gagal menyimpan kunci API: {error}",
+    "apiKeyRestartHint": "Perubahan berlaku setelah aplikasi dimulai ulang."
   },
   "format": {
     "justNow": "baru saja",

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -514,3 +514,8 @@ export interface AllocationItemResponse {
   value: number;
   pct: number;
 }
+
+export interface APIKeyStatusResponse {
+  fmpConfigured: boolean;
+  sectorsConfigured: boolean;
+}

--- a/frontend/src/pages/settings/SettingsPage.svelte
+++ b/frontend/src/pages/settings/SettingsPage.svelte
@@ -2,10 +2,13 @@
 import { onMount } from "svelte";
 import {
   CheckForUpdate,
+  ClearFMPAPIKey,
+  ClearSectorsAPIKey,
   CreateManualBackup,
   DownloadAndInstallUpdate,
   ExportData,
   ExportLogs,
+  GetAPIKeyStatus,
   GetAppVersion,
   GetBackupStatus,
   GetLogStats,
@@ -16,7 +19,9 @@ import {
   IsDebugMode,
   RunProviderHealthCheck,
   SetDebugMode,
+  SetFMPAPIKey,
   SetProviderEnabled,
+  SetSectorsAPIKey,
   TriggerRefresh,
   UpdateRefreshSettings,
 } from "../../../wailsjs/go/backend/App";
@@ -70,6 +75,13 @@ type ProviderStatus = {
 
 let providers = $state<ProviderStatus[]>([]);
 let healthChecking = $state(false);
+
+let fmpConfigured = $state(false);
+let sectorsConfigured = $state(false);
+let fmpKeyInput = $state("");
+let sectorsKeyInput = $state("");
+let savingFmpKey = $state(false);
+let savingSectorsKey = $state(false);
 
 let debugMode = $state(false);
 let logStats = $state<{
@@ -131,6 +143,14 @@ onMount(async () => {
 
   try {
     providers = await GetProviderStatus();
+  } catch {
+    // non-critical
+  }
+
+  try {
+    const keyStatus = await GetAPIKeyStatus();
+    fmpConfigured = keyStatus.fmpConfigured;
+    sectorsConfigured = keyStatus.sectorsConfigured;
   } catch {
     // non-critical
   }
@@ -230,6 +250,60 @@ async function checkProviderHealth() {
     // non-critical
   } finally {
     healthChecking = false;
+  }
+}
+
+async function saveFmpKey() {
+  if (!fmpKeyInput.trim()) return;
+  savingFmpKey = true;
+  try {
+    await SetFMPAPIKey(fmpKeyInput.trim());
+    fmpConfigured = true;
+    fmpKeyInput = "";
+    toastStore.add(t("settings.apiKeySaved"), "success");
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    toastStore.add(t("settings.apiKeySaveError", { error: msg }), "error");
+  } finally {
+    savingFmpKey = false;
+  }
+}
+
+async function clearFmpKey() {
+  try {
+    await ClearFMPAPIKey();
+    fmpConfigured = false;
+    toastStore.add(t("settings.apiKeyCleared"), "success");
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    toastStore.add(msg, "error");
+  }
+}
+
+async function saveSectorsKey() {
+  if (!sectorsKeyInput.trim()) return;
+  savingSectorsKey = true;
+  try {
+    await SetSectorsAPIKey(sectorsKeyInput.trim());
+    sectorsConfigured = true;
+    sectorsKeyInput = "";
+    toastStore.add(t("settings.apiKeySaved"), "success");
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    toastStore.add(t("settings.apiKeySaveError", { error: msg }), "error");
+  } finally {
+    savingSectorsKey = false;
+  }
+}
+
+async function clearSectorsKey() {
+  try {
+    await ClearSectorsAPIKey();
+    sectorsConfigured = false;
+    toastStore.add(t("settings.apiKeyCleared"), "success");
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    toastStore.add(msg, "error");
   }
 }
 
@@ -442,6 +516,81 @@ async function confirmImport() {
         >
           {healthChecking ? t("settings.providerCheckingHealth") : t("settings.providerCheckHealth")}
         </button>
+      </div>
+    </div>
+
+    <div>
+      <p class="mb-3 text-sm text-text-secondary">
+        <Tooltip text={t("settings.apiKeysTooltip")}>
+          <span class="underline decoration-dotted cursor-help">{t("settings.apiKeys")}</span>
+        </Tooltip>
+      </p>
+      <div class="space-y-4 rounded-lg border border-border-default bg-bg-elevated p-4">
+        <div>
+          <div class="mb-2 flex items-center justify-between">
+            <span class="text-sm font-medium text-text-primary">{t("settings.fmpApiKey")}</span>
+            <span class="text-xs {fmpConfigured ? 'text-profit' : 'text-text-tertiary'}">
+              {fmpConfigured ? t("settings.apiKeyConfigured") : t("settings.apiKeyNotConfigured")}
+            </span>
+          </div>
+          <div class="flex gap-2">
+            <input
+              type="password"
+              bind:value={fmpKeyInput}
+              placeholder={t("settings.apiKeyPlaceholder")}
+              class="flex-1 rounded border border-border-default bg-bg-primary px-3 py-1.5 text-sm text-text-primary placeholder:text-text-tertiary focus-ring"
+            />
+            <button
+              onclick={saveFmpKey}
+              disabled={savingFmpKey || !fmpKeyInput.trim()}
+              class="rounded border border-green-700 px-3 py-1.5 text-sm font-medium text-green-700 transition-fast hover:bg-green-100 disabled:opacity-60 focus-ring dark:hover:bg-green-900/30"
+            >
+              {t("settings.apiKeySave")}
+            </button>
+            {#if fmpConfigured}
+              <button
+                onclick={clearFmpKey}
+                class="rounded border border-loss px-3 py-1.5 text-sm font-medium text-loss transition-fast hover:bg-red-100 focus-ring dark:hover:bg-red-900/30"
+              >
+                {t("settings.apiKeyClear")}
+              </button>
+            {/if}
+          </div>
+        </div>
+
+        <div>
+          <div class="mb-2 flex items-center justify-between">
+            <span class="text-sm font-medium text-text-primary">{t("settings.sectorsApiKey")}</span>
+            <span class="text-xs {sectorsConfigured ? 'text-profit' : 'text-text-tertiary'}">
+              {sectorsConfigured ? t("settings.apiKeyConfigured") : t("settings.apiKeyNotConfigured")}
+            </span>
+          </div>
+          <div class="flex gap-2">
+            <input
+              type="password"
+              bind:value={sectorsKeyInput}
+              placeholder={t("settings.apiKeyPlaceholder")}
+              class="flex-1 rounded border border-border-default bg-bg-primary px-3 py-1.5 text-sm text-text-primary placeholder:text-text-tertiary focus-ring"
+            />
+            <button
+              onclick={saveSectorsKey}
+              disabled={savingSectorsKey || !sectorsKeyInput.trim()}
+              class="rounded border border-green-700 px-3 py-1.5 text-sm font-medium text-green-700 transition-fast hover:bg-green-100 disabled:opacity-60 focus-ring dark:hover:bg-green-900/30"
+            >
+              {t("settings.apiKeySave")}
+            </button>
+            {#if sectorsConfigured}
+              <button
+                onclick={clearSectorsKey}
+                class="rounded border border-loss px-3 py-1.5 text-sm font-medium text-loss transition-fast hover:bg-red-100 focus-ring dark:hover:bg-red-900/30"
+              >
+                {t("settings.apiKeyClear")}
+              </button>
+            {/if}
+          </div>
+        </div>
+
+        <p class="text-xs text-text-tertiary">{t("settings.apiKeyRestartHint")}</p>
       </div>
     </div>
     {/if}


### PR DESCRIPTION
## Issue
N/A

## Summary
- Add full financial statement data support (income statement, balance sheet, cash flow) with historical periods (quarterly + annual)
- Two new providers: Financial Modeling Prep (FMP) as primary, SectorsApp as fallback
- New `FinancialStatementProvider` interface separate from `DataProvider`, with its own priority-based registry
- Database migration V13 with three new tables and period-aware unique constraints
- Use case with 24h cache TTL via `LatestFetchedAt`
- API key settings handler (keys stored in `app_settings`, never exposed to frontend)
- Frontend settings UI for managing API keys in the Data tab

## Test Plan
- [x] Linter passes (`make lint`)
- [x] All backend tests pass (`make test-go`) — 31 packages, 0 failures
- [x] Biome check passes on frontend files
- [ ] Manual: `make dev` → Settings > Data → enter FMP API key, verify status shows "Configured"
- [ ] Manual: clear API key, verify status shows "Not configured"
- [ ] Manual: verify restart hint is shown after key changes

## Notes
- API key changes require app restart — hot-reload is a follow-up
- SectorsApp API endpoints are stubbed based on available docs; may need adjustment against the live API
- `dupl` linter exclusion added for `_test.go` files — repo tests are structurally similar across entity types by design