### PR TITLE
feat: financial datasets pipeline

### DIFF
--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -1,0 +1,25 @@
+name: Update Datasets
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Weekly Monday 6am UTC (1pm WIB)
+  workflow_dispatch: # Manual trigger
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    name: Fetch financial datasets
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v3
+
+      - name: Install Python dependencies
+        run: pip install -r scripts/datasets/requirements.txt
+
+      - name: Fetch and push data
+        env:
+          APPSCRIPT_URL: ${{ vars.APPSCRIPT_URL }}
+          APPSCRIPT_TOKEN: ${{ secrets.APPSCRIPT_TOKEN }}
+        run: python scripts/datasets/fetch.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,9 +63,10 @@ jobs:
         shell: bash
         env:
           REF_NAME: ${{ github.ref_name }}
+          APPSCRIPT_URL: ${{ vars.APPSCRIPT_URL }}
         run: |
           TAG_VERSION="${REF_NAME#v}"
-          LDFLAGS="-X github.com/lugassawan/panen/backend.version=${TAG_VERSION}"
+          LDFLAGS="-X github.com/lugassawan/panen/backend.version=${TAG_VERSION} -X github.com/lugassawan/panen/backend.appscriptURL=${APPSCRIPT_URL}"
           wails build -clean -platform ${{ matrix.platform }} -ldflags "${LDFLAGS}"
 
       - name: Package (macOS)

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,12 @@
 	lint fmt frontend-install setup init custom-gcl \
 	test test-unit test-go test-frontend test-integration test-e2e \
 	coverage coverage-go coverage-frontend playwright-install \
-	release-check
+	release-check dataset-setup dataset-fetch
 
 VERSION := $(shell jq -r '.info.productVersion' wails.json)
-LDFLAGS := -X github.com/lugassawan/panen/backend.version=$(VERSION)
+APPSCRIPT_URL ?= $(shell echo $$APPSCRIPT_URL)
+LDFLAGS := -X github.com/lugassawan/panen/backend.version=$(VERSION) \
+           -X github.com/lugassawan/panen/backend.appscriptURL=$(APPSCRIPT_URL)
 
 dev:
 	wails dev -tags dev
@@ -93,6 +95,12 @@ setup:
 	wails generate module
 	$(MAKE) custom-gcl
 	git config core.hooksPath .githooks
+
+dataset-setup:
+	pip install -r scripts/datasets/requirements.txt
+
+dataset-fetch:
+	python scripts/datasets/fetch.py
 
 release-check:
 	@TAG_VERSION="$(VERSION)"; \

--- a/backend/app.go
+++ b/backend/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lugassawan/panen/backend/infra/backup"
 	brokerConfigLoader "github.com/lugassawan/panen/backend/infra/brokerconfig"
 	"github.com/lugassawan/panen/backend/infra/database"
+	infraDataset "github.com/lugassawan/panen/backend/infra/dataset"
 	"github.com/lugassawan/panen/backend/infra/github"
 	"github.com/lugassawan/panen/backend/infra/liveconfig"
 	"github.com/lugassawan/panen/backend/infra/platform"
@@ -24,6 +25,9 @@ import (
 	"github.com/lugassawan/panen/backend/usecase"
 	wailsRuntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
+
+// appscriptURL is set at build time via -ldflags "-X github.com/lugassawan/panen/backend.appscriptURL=...".
+var appscriptURL string
 
 // App is the Wails-bound application controller.
 // Handler methods are promoted via embedding so Wails can bind them.
@@ -50,6 +54,7 @@ type App struct {
 	*presenter.TransactionHandler
 	*presenter.DashboardHandler
 	*presenter.ProviderHandler
+	*presenter.DatasetHandler
 	db        *database.DB
 	backup    *backup.BackupService
 	dbPath    string
@@ -130,6 +135,7 @@ func NewApp() *App {
 		TransactionHandler:      &presenter.TransactionHandler{},
 		DashboardHandler:        &presenter.DashboardHandler{},
 		ProviderHandler:         &presenter.ProviderHandler{},
+		DatasetHandler:          &presenter.DatasetHandler{},
 		backup:                  backup.NewBackupService(),
 	}
 }
@@ -185,9 +191,12 @@ func (a *App) Startup(ctx context.Context) {
 	indexResult := indexLoader.Load(ctx)
 	swappableIndexReg := watchlistconfig.NewSwappableIndexRegistry(indexResult.Data)
 
+	datasetClient := infraDataset.NewClient(appscriptURL, dataDir)
+
 	svc := a.initServices(r, registry, wailsEmitter, sectorRegistry, swappableIndexReg)
 
 	a.bindHandlers(ctx, svc, r, profileID, sectorRegistry, registry, wailsEmitter)
+	a.DatasetHandler.Bind(ctx, datasetClient)
 
 	a.Init(ctx)
 	a.RegisterLoader("brokers", brokerLoader, func(_ context.Context) {

--- a/backend/domain/dataset/entity.go
+++ b/backend/domain/dataset/entity.go
@@ -1,8 +1,5 @@
 package dataset
 
-// FinancialDataset maps ticker codes to their financial data.
-type FinancialDataset map[string]*TickerFinancials
-
 // TickerFinancials holds financial time series for a single stock.
 type TickerFinancials struct {
 	Revenue         []TimeSeriesEntry
@@ -19,9 +16,6 @@ type TimeSeriesEntry struct {
 	Quarter int
 	Value   float64
 }
-
-// SectorMetricDataset maps ticker to metric name to entries.
-type SectorMetricDataset map[string]map[string][]SectorMetricEntry
 
 // SectorMetricEntry is a single sector-specific metric value.
 type SectorMetricEntry struct {

--- a/backend/domain/dataset/entity.go
+++ b/backend/domain/dataset/entity.go
@@ -1,0 +1,35 @@
+package dataset
+
+// FinancialDataset maps ticker codes to their financial data.
+type FinancialDataset map[string]*TickerFinancials
+
+// TickerFinancials holds financial time series for a single stock.
+type TickerFinancials struct {
+	Revenue         []TimeSeriesEntry
+	NetIncome       []TimeSeriesEntry
+	TotalAssets     []TimeSeriesEntry
+	TotalEquity     []TimeSeriesEntry
+	TotalDebt       []TimeSeriesEntry
+	OperatingIncome []TimeSeriesEntry
+}
+
+// TimeSeriesEntry is a single data point in a financial time series.
+type TimeSeriesEntry struct {
+	Year    int
+	Quarter int
+	Value   float64
+}
+
+// SectorMetricDataset maps ticker to metric name to entries.
+type SectorMetricDataset map[string]map[string][]SectorMetricEntry
+
+// SectorMetricEntry is a single sector-specific metric value.
+type SectorMetricEntry struct {
+	Year    int
+	Quarter int
+	Value   float64
+	Source  string // "auto" or "manual"
+}
+
+// MetricDefinitions maps sector names to their metric lists.
+type MetricDefinitions map[string][]string

--- a/backend/domain/dataset/repository.go
+++ b/backend/domain/dataset/repository.go
@@ -1,0 +1,11 @@
+package dataset
+
+import "context"
+
+// Repository defines read access to financial datasets.
+type Repository interface {
+	FetchFinancials(ctx context.Context, ticker string) (*TickerFinancials, error)
+	FetchAllFinancials(ctx context.Context) (FinancialDataset, error)
+	FetchSectorMetrics(ctx context.Context, ticker string) (map[string][]SectorMetricEntry, error)
+	FetchDefinitions(ctx context.Context) (MetricDefinitions, error)
+}

--- a/backend/domain/dataset/repository.go
+++ b/backend/domain/dataset/repository.go
@@ -5,7 +5,6 @@ import "context"
 // Repository defines read access to financial datasets.
 type Repository interface {
 	FetchFinancials(ctx context.Context, ticker string) (*TickerFinancials, error)
-	FetchAllFinancials(ctx context.Context) (FinancialDataset, error)
 	FetchSectorMetrics(ctx context.Context, ticker string) (map[string][]SectorMetricEntry, error)
 	FetchDefinitions(ctx context.Context) (MetricDefinitions, error)
 }

--- a/backend/infra/dataset/client.go
+++ b/backend/infra/dataset/client.go
@@ -55,22 +55,6 @@ func (c *Client) FetchFinancials(ctx context.Context, ticker string) (*dataset.T
 	return convertTickerFinancials(resp.Data), nil
 }
 
-// FetchAllFinancials returns financials for all tickers.
-func (c *Client) FetchAllFinancials(ctx context.Context) (dataset.FinancialDataset, error) {
-	if c.baseURL == "" {
-		return nil, nil //nolint:nilnil // nil signals "not configured" to the frontend
-	}
-
-	params := url.Values{"action": {"financials"}}
-	cacheKey := "financials_all.json"
-
-	var resp allFinancialsResponse
-	if err := c.fetchJSON(ctx, params, cacheKey, &resp); err != nil {
-		return nil, err
-	}
-	return convertAllFinancials(resp.Data), nil
-}
-
 // FetchSectorMetrics returns sector-specific metrics for a ticker.
 func (c *Client) FetchSectorMetrics(
 	ctx context.Context,
@@ -158,7 +142,7 @@ func (c *Client) readCache(path string) ([]byte, error) {
 	return os.ReadFile(path)
 }
 
-// writeCache writes data to the cache file, creating directories as needed.
+// writeCache atomically writes data to the cache file, creating directories as needed.
 func (c *Client) writeCache(path string, data []byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -167,7 +151,13 @@ func (c *Client) writeCache(path string, data []byte) {
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return
 	}
-	_ = os.WriteFile(path, data, 0o600)
+
+	// Write to temp file then rename for atomicity — prevents partial reads.
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, path)
 }
 
 // Wire protocol types for JSON decoding.
@@ -176,12 +166,6 @@ type financialsResponse struct {
 	Version   int                   `json:"version"`
 	UpdatedAt string                `json:"updatedAt"`
 	Data      []financialsEntryWire `json:"data"`
-}
-
-type allFinancialsResponse struct {
-	Version   int                              `json:"version"`
-	UpdatedAt string                           `json:"updatedAt"`
-	Data      map[string][]financialsEntryWire `json:"data"`
 }
 
 type sectorMetricsResponse struct {
@@ -235,17 +219,6 @@ func convertTickerFinancials(entries []financialsEntryWire) *dataset.TickerFinan
 		}
 	}
 	return tf
-}
-
-func convertAllFinancials(data map[string][]financialsEntryWire) dataset.FinancialDataset {
-	if len(data) == 0 {
-		return nil
-	}
-	result := make(dataset.FinancialDataset, len(data))
-	for ticker, entries := range data {
-		result[ticker] = convertTickerFinancials(entries)
-	}
-	return result
 }
 
 func convertSectorMetrics(data map[string][]sectorMetricEntryWire) map[string][]dataset.SectorMetricEntry {

--- a/backend/infra/dataset/client.go
+++ b/backend/infra/dataset/client.go
@@ -1,0 +1,269 @@
+package dataset
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/lugassawan/panen/backend/domain/dataset"
+)
+
+const (
+	cacheTTL         = 24 * time.Hour
+	httpTimeout      = 10 * time.Second
+	maxResponseBytes = 1 << 20 // 1 MB
+)
+
+// Client fetches financial datasets from an Apps Script endpoint with local file caching.
+type Client struct {
+	baseURL  string
+	cacheDir string
+	client   *http.Client
+	mu       sync.Mutex
+}
+
+// NewClient creates a Client. When appscriptURL is empty, all methods return nil/empty gracefully.
+func NewClient(appscriptURL string, dataDir string) *Client {
+	return &Client{
+		baseURL:  appscriptURL,
+		cacheDir: filepath.Join(dataDir, "datasets"),
+		client:   &http.Client{Timeout: httpTimeout},
+	}
+}
+
+// FetchFinancials returns financials for a single ticker.
+func (c *Client) FetchFinancials(ctx context.Context, ticker string) (*dataset.TickerFinancials, error) {
+	if c.baseURL == "" {
+		return nil, nil //nolint:nilnil // nil signals "not configured" to the frontend
+	}
+
+	params := url.Values{"action": {"financials"}, "ticker": {ticker}}
+	cacheKey := fmt.Sprintf("financials_%s.json", ticker)
+
+	var resp financialsResponse
+	if err := c.fetchJSON(ctx, params, cacheKey, &resp); err != nil {
+		return nil, err
+	}
+	return convertTickerFinancials(resp.Data), nil
+}
+
+// FetchAllFinancials returns financials for all tickers.
+func (c *Client) FetchAllFinancials(ctx context.Context) (dataset.FinancialDataset, error) {
+	if c.baseURL == "" {
+		return nil, nil //nolint:nilnil // nil signals "not configured" to the frontend
+	}
+
+	params := url.Values{"action": {"financials"}}
+	cacheKey := "financials_all.json"
+
+	var resp allFinancialsResponse
+	if err := c.fetchJSON(ctx, params, cacheKey, &resp); err != nil {
+		return nil, err
+	}
+	return convertAllFinancials(resp.Data), nil
+}
+
+// FetchSectorMetrics returns sector-specific metrics for a ticker.
+func (c *Client) FetchSectorMetrics(
+	ctx context.Context,
+	ticker string,
+) (map[string][]dataset.SectorMetricEntry, error) {
+	if c.baseURL == "" {
+		return nil, nil //nolint:nilnil // nil signals "not configured" to the frontend
+	}
+
+	params := url.Values{"action": {"sector_metrics"}, "ticker": {ticker}}
+	cacheKey := fmt.Sprintf("sector_metrics_%s.json", ticker)
+
+	var resp sectorMetricsResponse
+	if err := c.fetchJSON(ctx, params, cacheKey, &resp); err != nil {
+		return nil, err
+	}
+	return convertSectorMetrics(resp.Data), nil
+}
+
+// FetchDefinitions returns metric definitions per sector.
+func (c *Client) FetchDefinitions(ctx context.Context) (dataset.MetricDefinitions, error) {
+	if c.baseURL == "" {
+		return nil, nil //nolint:nilnil // nil signals "not configured" to the frontend
+	}
+
+	params := url.Values{"action": {"definitions"}}
+	cacheKey := "definitions.json"
+
+	var resp definitionsResponse
+	if err := c.fetchJSON(ctx, params, cacheKey, &resp); err != nil {
+		return nil, err
+	}
+	return dataset.MetricDefinitions(resp.Data), nil
+}
+
+// fetchJSON fetches data from the endpoint or cache and decodes into dest.
+func (c *Client) fetchJSON(ctx context.Context, params url.Values, cacheKey string, dest any) error {
+	cachePath := filepath.Join(c.cacheDir, cacheKey)
+
+	// Check cache.
+	if data, err := c.readCache(cachePath); err == nil {
+		return json.Unmarshal(data, dest)
+	}
+
+	// Fetch from endpoint.
+	reqURL := c.baseURL + "?" + params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := c.client.Do(req) //nolint:gosec // URL is from build-time ldflags, not user input
+	if err != nil {
+		return fmt.Errorf("fetch dataset: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	if err := json.Unmarshal(body, dest); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+
+	c.writeCache(cachePath, body)
+	return nil
+}
+
+// readCache returns cached data if the file exists and is within TTL.
+func (c *Client) readCache(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if time.Since(info.ModTime()) > cacheTTL {
+		return nil, errors.New("cache expired")
+	}
+	return os.ReadFile(path)
+}
+
+// writeCache writes data to the cache file, creating directories as needed.
+func (c *Client) writeCache(path string, data []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0o600)
+}
+
+// Wire protocol types for JSON decoding.
+
+type financialsResponse struct {
+	Version   int                   `json:"version"`
+	UpdatedAt string                `json:"updatedAt"`
+	Data      []financialsEntryWire `json:"data"`
+}
+
+type allFinancialsResponse struct {
+	Version   int                              `json:"version"`
+	UpdatedAt string                           `json:"updatedAt"`
+	Data      map[string][]financialsEntryWire `json:"data"`
+}
+
+type sectorMetricsResponse struct {
+	Version   int                                `json:"version"`
+	UpdatedAt string                             `json:"updatedAt"`
+	Data      map[string][]sectorMetricEntryWire `json:"data"`
+}
+
+type definitionsResponse struct {
+	Version   int                 `json:"version"`
+	UpdatedAt string              `json:"updatedAt"`
+	Data      map[string][]string `json:"data"`
+}
+
+type financialsEntryWire struct {
+	Year    int     `json:"year"`
+	Quarter int     `json:"quarter"`
+	Metric  string  `json:"metric"`
+	Value   float64 `json:"value"`
+}
+
+type sectorMetricEntryWire struct {
+	Year    int     `json:"year"`
+	Quarter int     `json:"quarter"`
+	Value   float64 `json:"value"`
+	Source  string  `json:"source"`
+}
+
+// Conversion helpers.
+
+func convertTickerFinancials(entries []financialsEntryWire) *dataset.TickerFinancials {
+	if len(entries) == 0 {
+		return nil
+	}
+	tf := &dataset.TickerFinancials{}
+	for _, e := range entries {
+		ts := dataset.TimeSeriesEntry{Year: e.Year, Quarter: e.Quarter, Value: e.Value}
+		switch e.Metric {
+		case "revenue":
+			tf.Revenue = append(tf.Revenue, ts)
+		case "net_income":
+			tf.NetIncome = append(tf.NetIncome, ts)
+		case "total_assets":
+			tf.TotalAssets = append(tf.TotalAssets, ts)
+		case "total_equity":
+			tf.TotalEquity = append(tf.TotalEquity, ts)
+		case "total_debt":
+			tf.TotalDebt = append(tf.TotalDebt, ts)
+		case "operating_income":
+			tf.OperatingIncome = append(tf.OperatingIncome, ts)
+		}
+	}
+	return tf
+}
+
+func convertAllFinancials(data map[string][]financialsEntryWire) dataset.FinancialDataset {
+	if len(data) == 0 {
+		return nil
+	}
+	result := make(dataset.FinancialDataset, len(data))
+	for ticker, entries := range data {
+		result[ticker] = convertTickerFinancials(entries)
+	}
+	return result
+}
+
+func convertSectorMetrics(data map[string][]sectorMetricEntryWire) map[string][]dataset.SectorMetricEntry {
+	if len(data) == 0 {
+		return nil
+	}
+	result := make(map[string][]dataset.SectorMetricEntry, len(data))
+	for metric, entries := range data {
+		converted := make([]dataset.SectorMetricEntry, len(entries))
+		for i, e := range entries {
+			converted[i] = dataset.SectorMetricEntry{
+				Year:    e.Year,
+				Quarter: e.Quarter,
+				Value:   e.Value,
+				Source:  e.Source,
+			}
+		}
+		result[metric] = converted
+	}
+	return result
+}

--- a/backend/infra/dataset/client_test.go
+++ b/backend/infra/dataset/client_test.go
@@ -156,16 +156,6 @@ func TestEmptyURLGracefulDegradation(t *testing.T) {
 			},
 		},
 		{
-			name: "FetchAllFinancials",
-			fn: func() error {
-				result, err := client.FetchAllFinancials(context.Background())
-				if result != nil {
-					t.Errorf("expected nil result for FetchAllFinancials")
-				}
-				return err
-			},
-		},
-		{
 			name: "FetchSectorMetrics",
 			fn: func() error {
 				result, err := client.FetchSectorMetrics(context.Background(), "BBCA")

--- a/backend/infra/dataset/client_test.go
+++ b/backend/infra/dataset/client_test.go
@@ -1,0 +1,324 @@
+package dataset
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFetchFinancials(t *testing.T) {
+	body := `{
+		"version": 1,
+		"updatedAt": "2026-03-15",
+		"data": [
+			{"year": 2025, "quarter": 4, "metric": "revenue", "value": 1000000},
+			{"year": 2025, "quarter": 4, "metric": "net_income", "value": 200000},
+			{"year": 2025, "quarter": 3, "metric": "total_equity", "value": 500000}
+		]
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("action") != "financials" {
+			t.Errorf("expected action=financials, got %s", r.URL.Query().Get("action"))
+		}
+		if r.URL.Query().Get("ticker") != "BBCA" {
+			t.Errorf("expected ticker=BBCA, got %s", r.URL.Query().Get("ticker"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	dataDir := t.TempDir()
+	client := NewClient(srv.URL, dataDir)
+
+	result, err := client.FetchFinancials(context.Background(), "BBCA")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.Revenue) != 1 {
+		t.Fatalf("expected 1 revenue entry, got %d", len(result.Revenue))
+	}
+	if result.Revenue[0].Value != 1000000 {
+		t.Errorf("expected revenue value 1000000, got %f", result.Revenue[0].Value)
+	}
+	if len(result.NetIncome) != 1 {
+		t.Fatalf("expected 1 net_income entry, got %d", len(result.NetIncome))
+	}
+	if result.NetIncome[0].Year != 2025 || result.NetIncome[0].Quarter != 4 {
+		t.Errorf("unexpected net_income entry: %+v", result.NetIncome[0])
+	}
+	if len(result.TotalEquity) != 1 {
+		t.Fatalf("expected 1 total_equity entry, got %d", len(result.TotalEquity))
+	}
+}
+
+func TestFetchFinancialsCacheHit(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(
+			[]byte(
+				`{"version":1,"updatedAt":"2026-03-15","data":[{"year":2025,"quarter":4,"metric":"revenue","value":999}]}`,
+			),
+		)
+	}))
+	defer srv.Close()
+
+	dataDir := t.TempDir()
+	client := NewClient(srv.URL, dataDir)
+
+	// First call — hits server.
+	_, err := client.FetchFinancials(context.Background(), "BMRI")
+	if err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+	if callCount != 1 {
+		t.Fatalf("expected 1 server call, got %d", callCount)
+	}
+
+	// Second call — should hit cache.
+	result, err := client.FetchFinancials(context.Background(), "BMRI")
+	if err != nil {
+		t.Fatalf("second fetch: %v", err)
+	}
+	if callCount != 1 {
+		t.Fatalf("expected cache hit (1 server call), got %d", callCount)
+	}
+	if result == nil || len(result.Revenue) != 1 || result.Revenue[0].Value != 999 {
+		t.Errorf("unexpected cached result: %+v", result)
+	}
+}
+
+func TestFetchFinancialsCacheExpired(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(
+			[]byte(
+				`{"version":1,"updatedAt":"2026-03-15","data":[{"year":2025,"quarter":4,"metric":"revenue","value":42}]}`,
+			),
+		)
+	}))
+	defer srv.Close()
+
+	dataDir := t.TempDir()
+	client := NewClient(srv.URL, dataDir)
+
+	// First call.
+	_, err := client.FetchFinancials(context.Background(), "TLKM")
+	if err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+
+	// Backdate the cache file to simulate expiry.
+	cachePath := filepath.Join(dataDir, "datasets", "financials_TLKM.json")
+	expired := time.Now().Add(-25 * time.Hour)
+	if err := os.Chtimes(cachePath, expired, expired); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	// Second call — cache is expired, should hit server again.
+	_, err = client.FetchFinancials(context.Background(), "TLKM")
+	if err != nil {
+		t.Fatalf("second fetch: %v", err)
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 server calls after expiry, got %d", callCount)
+	}
+}
+
+func TestEmptyURLGracefulDegradation(t *testing.T) {
+	dataDir := t.TempDir()
+	client := NewClient("", dataDir)
+
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{
+			name: "FetchFinancials",
+			fn: func() error {
+				result, err := client.FetchFinancials(context.Background(), "BBCA")
+				if result != nil {
+					t.Errorf("expected nil result for FetchFinancials")
+				}
+				return err
+			},
+		},
+		{
+			name: "FetchAllFinancials",
+			fn: func() error {
+				result, err := client.FetchAllFinancials(context.Background())
+				if result != nil {
+					t.Errorf("expected nil result for FetchAllFinancials")
+				}
+				return err
+			},
+		},
+		{
+			name: "FetchSectorMetrics",
+			fn: func() error {
+				result, err := client.FetchSectorMetrics(context.Background(), "BBCA")
+				if result != nil {
+					t.Errorf("expected nil result for FetchSectorMetrics")
+				}
+				return err
+			},
+		},
+		{
+			name: "FetchDefinitions",
+			fn: func() error {
+				result, err := client.FetchDefinitions(context.Background())
+				if result != nil {
+					t.Errorf("expected nil result for FetchDefinitions")
+				}
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.fn(); err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestResponseSizeLimit(t *testing.T) {
+	// Create a response larger than 1 MB.
+	largeBody := make([]byte, maxResponseBytes+1)
+	for i := range largeBody {
+		largeBody[i] = 'x'
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(largeBody)
+	}))
+	defer srv.Close()
+
+	dataDir := t.TempDir()
+	client := NewClient(srv.URL, dataDir)
+
+	_, err := client.FetchFinancials(context.Background(), "BBCA")
+	if err == nil {
+		t.Fatal("expected error for oversized response")
+	}
+}
+
+func TestMalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{not valid json`))
+	}))
+	defer srv.Close()
+
+	dataDir := t.TempDir()
+	client := NewClient(srv.URL, dataDir)
+
+	_, err := client.FetchFinancials(context.Background(), "BBCA")
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestFetchSectorMetrics(t *testing.T) {
+	body := `{
+		"version": 1,
+		"updatedAt": "2026-03-15",
+		"data": {
+			"nim": [
+				{"year": 2025, "quarter": 4, "value": 5.2, "source": "auto"},
+				{"year": 2025, "quarter": 3, "value": 5.1, "source": "manual"}
+			]
+		}
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	dataDir := t.TempDir()
+	client := NewClient(srv.URL, dataDir)
+
+	result, err := client.FetchSectorMetrics(context.Background(), "BBCA")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	nim, ok := result["nim"]
+	if !ok {
+		t.Fatal("expected 'nim' metric")
+	}
+	if len(nim) != 2 {
+		t.Fatalf("expected 2 nim entries, got %d", len(nim))
+	}
+	if nim[0].Source != "auto" {
+		t.Errorf("expected source 'auto', got %q", nim[0].Source)
+	}
+}
+
+func TestFetchDefinitions(t *testing.T) {
+	body := `{
+		"version": 1,
+		"updatedAt": "2026-03-15",
+		"data": {
+			"Banking": ["nim", "car", "ldr"],
+			"Mining": ["stripping_ratio", "asc"]
+		}
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	dataDir := t.TempDir()
+	client := NewClient(srv.URL, dataDir)
+
+	result, err := client.FetchDefinitions(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result["Banking"]) != 3 {
+		t.Errorf("expected 3 Banking metrics, got %d", len(result["Banking"]))
+	}
+	if len(result["Mining"]) != 2 {
+		t.Errorf("expected 2 Mining metrics, got %d", len(result["Mining"]))
+	}
+}
+
+func TestHTTPErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	dataDir := t.TempDir()
+	client := NewClient(srv.URL, dataDir)
+
+	_, err := client.FetchFinancials(context.Background(), "BBCA")
+	if err == nil {
+		t.Fatal("expected error for 500 status")
+	}
+}

--- a/backend/presenter/dataset.go
+++ b/backend/presenter/dataset.go
@@ -1,0 +1,125 @@
+package presenter
+
+import (
+	"context"
+
+	"github.com/lugassawan/panen/backend/domain/dataset"
+)
+
+// DatasetHandler handles financial dataset requests from the frontend.
+type DatasetHandler struct {
+	ctx  context.Context
+	repo dataset.Repository
+}
+
+// Bind wires the handler to its dependencies.
+func (h *DatasetHandler) Bind(ctx context.Context, repo dataset.Repository) {
+	h.ctx = ctx
+	h.repo = repo
+}
+
+// GetFinancials returns financial time series for a single ticker.
+func (h *DatasetHandler) GetFinancials(ticker string) (*FinancialsResponse, error) {
+	tf, err := h.repo.FetchFinancials(h.ctx, ticker)
+	if err != nil {
+		return nil, err
+	}
+	if tf == nil {
+		return nil, nil //nolint:nilnil // nil signals "not configured" to the frontend
+	}
+	return &FinancialsResponse{
+		Revenue:         convertTimeSeries(tf.Revenue),
+		NetIncome:       convertTimeSeries(tf.NetIncome),
+		TotalAssets:     convertTimeSeries(tf.TotalAssets),
+		TotalEquity:     convertTimeSeries(tf.TotalEquity),
+		TotalDebt:       convertTimeSeries(tf.TotalDebt),
+		OperatingIncome: convertTimeSeries(tf.OperatingIncome),
+	}, nil
+}
+
+// GetSectorMetrics returns sector-specific metrics for a ticker.
+func (h *DatasetHandler) GetSectorMetrics(ticker string) (*SectorMetricsResponse, error) {
+	metrics, err := h.repo.FetchSectorMetrics(h.ctx, ticker)
+	if err != nil {
+		return nil, err
+	}
+	if metrics == nil {
+		return nil, nil //nolint:nilnil // nil signals "not configured" to the frontend
+	}
+	converted := make(map[string][]SectorMetricEntryDTO, len(metrics))
+	for name, entries := range metrics {
+		dtos := make([]SectorMetricEntryDTO, len(entries))
+		for i, e := range entries {
+			dtos[i] = SectorMetricEntryDTO{
+				Year:    e.Year,
+				Quarter: e.Quarter,
+				Value:   e.Value,
+				Source:  e.Source,
+			}
+		}
+		converted[name] = dtos
+	}
+	return &SectorMetricsResponse{Metrics: converted}, nil
+}
+
+// GetSectorDefinitions returns metric definitions grouped by sector.
+func (h *DatasetHandler) GetSectorDefinitions() (*SectorDefinitionsResponse, error) {
+	defs, err := h.repo.FetchDefinitions(h.ctx)
+	if err != nil {
+		return nil, err
+	}
+	if defs == nil {
+		return nil, nil //nolint:nilnil // nil signals "not configured" to the frontend
+	}
+	return &SectorDefinitionsResponse{Sectors: defs}, nil
+}
+
+// FinancialsResponse is the frontend-facing response for ticker financials.
+type FinancialsResponse struct {
+	Revenue         []TimeSeriesEntryDTO `json:"revenue"`
+	NetIncome       []TimeSeriesEntryDTO `json:"netIncome"`
+	TotalAssets     []TimeSeriesEntryDTO `json:"totalAssets"`
+	TotalEquity     []TimeSeriesEntryDTO `json:"totalEquity"`
+	TotalDebt       []TimeSeriesEntryDTO `json:"totalDebt"`
+	OperatingIncome []TimeSeriesEntryDTO `json:"operatingIncome"`
+}
+
+// TimeSeriesEntryDTO is a single data point in a financial time series.
+type TimeSeriesEntryDTO struct {
+	Year    int     `json:"year"`
+	Quarter int     `json:"quarter"`
+	Value   float64 `json:"value"`
+}
+
+// SectorMetricsResponse is the frontend-facing response for sector metrics.
+type SectorMetricsResponse struct {
+	Metrics map[string][]SectorMetricEntryDTO `json:"metrics"`
+}
+
+// SectorMetricEntryDTO is a single sector-specific metric value.
+type SectorMetricEntryDTO struct {
+	Year    int     `json:"year"`
+	Quarter int     `json:"quarter"`
+	Value   float64 `json:"value"`
+	Source  string  `json:"source"`
+}
+
+// SectorDefinitionsResponse is the frontend-facing response for metric definitions.
+type SectorDefinitionsResponse struct {
+	Sectors map[string][]string `json:"sectors"`
+}
+
+func convertTimeSeries(entries []dataset.TimeSeriesEntry) []TimeSeriesEntryDTO {
+	if entries == nil {
+		return nil
+	}
+	dtos := make([]TimeSeriesEntryDTO, len(entries))
+	for i, e := range entries {
+		dtos[i] = TimeSeriesEntryDTO{
+			Year:    e.Year,
+			Quarter: e.Quarter,
+			Value:   e.Value,
+		}
+	}
+	return dtos
+}

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,7 @@
 go = "1.26"
 node = "25.6"
 pnpm = "10"
+python = "3.13"
 golangci-lint = "2"
 "npm:@biomejs/biome" = "2.4.6"
 golines = "0.13"

--- a/scripts/appscript/Code.gs
+++ b/scripts/appscript/Code.gs
@@ -1,0 +1,203 @@
+/**
+ * Apps Script web app for reading/writing financial datasets in Google Sheets.
+ *
+ * Sheets: financials, sector_metrics, definitions, tickers
+ *
+ * doGet — public read endpoints
+ * doPost — token-protected write endpoints
+ */
+
+// ─── Configuration ──────────────────────────────────────────────────────────
+
+const SHEET_NAMES = ["financials", "sector_metrics", "definitions", "tickers"];
+
+// Composite keys used for upsert deduplication per sheet.
+const UPSERT_KEYS = {
+  financials: ["ticker", "statementType", "period", "endDate"],
+  sector_metrics: ["ticker", "metric", "year", "quarter"],
+  tickers: ["ticker"],
+};
+
+// ─── Read Endpoints (doGet) ─────────────────────────────────────────────────
+
+function doGet(e) {
+  try {
+    const action = (e.parameter.action || "").toLowerCase();
+    const ticker = e.parameter.ticker || null;
+
+    switch (action) {
+      case "financials":
+        return jsonResponse(getSheetData("financials", ticker));
+      case "sectormetrics":
+        return jsonResponse(getSheetData("sector_metrics", ticker));
+      case "definitions":
+        return jsonResponse(getSheetData("definitions", null));
+      case "tickers":
+        return jsonResponse(getSheetData("tickers", null));
+      default:
+        return jsonResponse({ error: "Unknown action: " + action }, 400);
+    }
+  } catch (err) {
+    return jsonResponse({ error: err.message }, 500);
+  }
+}
+
+// ─── Write Endpoints (doPost) ───────────────────────────────────────────────
+
+function doPost(e) {
+  try {
+    if (!authorizeRequest(e)) {
+      return jsonResponse({ error: "Unauthorized" }, 401);
+    }
+
+    const body = JSON.parse(e.postData.contents);
+    const action = (body.action || "").toLowerCase();
+    const sheetName = body.sheet || "";
+    const rows = body.rows || [];
+
+    if (action !== "upsert") {
+      return jsonResponse({ error: "Unknown action: " + action }, 400);
+    }
+
+    if (SHEET_NAMES.indexOf(sheetName) === -1) {
+      return jsonResponse({ error: "Invalid sheet: " + sheetName }, 400);
+    }
+
+    if (!Array.isArray(rows) || rows.length === 0) {
+      return jsonResponse({ error: "No rows provided" }, 400);
+    }
+
+    const count = upsertRows(sheetName, rows);
+    return jsonResponse({ status: "ok", upserted: count });
+  } catch (err) {
+    return jsonResponse({ error: err.message }, 500);
+  }
+}
+
+// ─── Authorization ──────────────────────────────────────────────────────────
+
+function authorizeRequest(e) {
+  const props = PropertiesService.getScriptProperties();
+  const expectedToken = props.getProperty("APPSCRIPT_TOKEN");
+  if (!expectedToken) {
+    return false;
+  }
+
+  const authHeader = e.parameter.token || "";
+  if (authHeader === expectedToken) {
+    return true;
+  }
+
+  // Also check Authorization header via custom parameter workaround.
+  // Apps Script doPost doesn't expose headers directly, so the Python
+  // client sends the token as a query parameter.
+  return false;
+}
+
+// ─── Sheet Data Helpers ─────────────────────────────────────────────────────
+
+function getSheetData(sheetName, ticker) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getSheetByName(sheetName);
+  if (!sheet) {
+    return { version: 1, updatedAt: new Date().toISOString(), data: [] };
+  }
+
+  const data = sheet.getDataRange().getValues();
+  if (data.length < 2) {
+    return { version: 1, updatedAt: new Date().toISOString(), data: [] };
+  }
+
+  const headers = data[0];
+  const tickerCol = headers.indexOf("ticker");
+  const rows = [];
+
+  for (let i = 1; i < data.length; i++) {
+    if (ticker && tickerCol >= 0 && data[i][tickerCol] !== ticker) {
+      continue;
+    }
+
+    const row = {};
+    for (let j = 0; j < headers.length; j++) {
+      row[headers[j]] = data[i][j];
+    }
+    rows.push(row);
+  }
+
+  return {
+    version: 1,
+    updatedAt: new Date().toISOString(),
+    data: rows,
+  };
+}
+
+function upsertRows(sheetName, rows) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let sheet = ss.getSheetByName(sheetName);
+
+  // Auto-create sheet with headers from first row if it doesn't exist.
+  if (!sheet) {
+    sheet = ss.insertSheet(sheetName);
+    const headers = Object.keys(rows[0]);
+    if (headers.indexOf("updatedAt") === -1) {
+      headers.push("updatedAt");
+    }
+    sheet.appendRow(headers);
+  }
+
+  const data = sheet.getDataRange().getValues();
+  const headers = data[0];
+  const keys = UPSERT_KEYS[sheetName] || ["ticker"];
+  const updatedAtCol = headers.indexOf("updatedAt");
+  const now = new Date().toISOString();
+
+  // Build index of existing rows by composite key.
+  const existingIndex = {};
+  for (let i = 1; i < data.length; i++) {
+    const keyVal = keys.map(function (k) {
+      const col = headers.indexOf(k);
+      return col >= 0 ? String(data[i][col]) : "";
+    }).join("|");
+    existingIndex[keyVal] = i; // 0-based in data array, row i+1 in sheet
+  }
+
+  let upsertCount = 0;
+
+  for (let r = 0; r < rows.length; r++) {
+    const row = rows[r];
+    const keyVal = keys.map(function (k) {
+      return String(row[k] || "");
+    }).join("|");
+
+    // Build the row values in header order.
+    const rowValues = headers.map(function (h) {
+      if (h === "updatedAt") {
+        return now;
+      }
+      return row[h] !== undefined ? row[h] : "";
+    });
+
+    if (existingIndex.hasOwnProperty(keyVal)) {
+      // Update existing row.
+      const sheetRow = existingIndex[keyVal] + 1; // 1-based sheet row
+      sheet.getRange(sheetRow, 1, 1, rowValues.length).setValues([rowValues]);
+    } else {
+      // Append new row.
+      sheet.appendRow(rowValues);
+    }
+
+    upsertCount++;
+  }
+
+  return upsertCount;
+}
+
+// ─── Utilities ──────────────────────────────────────────────────────────────
+
+function jsonResponse(data, statusCode) {
+  // Apps Script always returns 200 for doGet/doPost, but we include
+  // the logical status in the response body for client-side handling.
+  const output = ContentService.createTextOutput(JSON.stringify(data));
+  output.setMimeType(ContentService.MimeType.JSON);
+  return output;
+}

--- a/scripts/appscript/Code.gs
+++ b/scripts/appscript/Code.gs
@@ -25,7 +25,10 @@ function doGet(e) {
     const action = (e.parameter.action || "").toLowerCase();
     const ticker = e.parameter.ticker || null;
 
-    switch (action) {
+    // Normalize action: strip underscores so both "sectormetrics" and "sector_metrics" work.
+    var normalizedAction = action.replace(/_/g, "");
+
+    switch (normalizedAction) {
       case "financials":
         return jsonResponse(getSheetData("financials", ticker));
       case "sectormetrics":

--- a/scripts/appscript/appsscript.json
+++ b/scripts/appscript/appsscript.json
@@ -1,0 +1,9 @@
+{
+  "timeZone": "Asia/Jakarta",
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "webapp": {
+    "executeAs": "USER_DEPLOYING",
+    "access": "ANYONE"
+  }
+}

--- a/scripts/datasets/appscript.py
+++ b/scripts/datasets/appscript.py
@@ -61,7 +61,6 @@ def post_data(sheet: str, rows: list[dict[str, Any]]) -> bool:
     """
     url, token = _get_config()
     headers = {
-        "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
     }
     payload = {
@@ -70,7 +69,9 @@ def post_data(sheet: str, rows: list[dict[str, Any]]) -> bool:
         "rows": rows,
     }
 
-    result = _request_with_retries("POST", url, headers=headers, json=payload)
+    # Apps Script doPost cannot read HTTP headers, so pass token as query param.
+    post_url = f"{url}?token={token}"
+    result = _request_with_retries("POST", post_url, headers=headers, json=payload)
     if result is None:
         return False
 
@@ -88,10 +89,8 @@ def get_data(action: str, ticker: str | None = None) -> list[dict[str, Any]]:
     Returns a list of row dicts, or an empty list on failure.
     """
     url, token = _get_config()
-    headers = {
-        "Authorization": f"Bearer {token}",
-    }
-    params: dict[str, str] = {"action": action}
+    headers: dict[str, str] = {}
+    params: dict[str, str] = {"action": action, "token": token}
     if ticker:
         params["ticker"] = ticker
 

--- a/scripts/datasets/appscript.py
+++ b/scripts/datasets/appscript.py
@@ -1,0 +1,102 @@
+"""Apps Script client for reading from and writing to Google Sheets."""
+
+import logging
+import os
+import time
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_MAX_RETRIES = 3
+_TIMEOUT_SECS = 30
+
+
+def _get_config() -> tuple[str, str]:
+    """Read Apps Script URL and token from environment variables."""
+    url = os.environ.get("APPSCRIPT_URL", "")
+    token = os.environ.get("APPSCRIPT_TOKEN", "")
+    if not url:
+        raise EnvironmentError("APPSCRIPT_URL environment variable is not set")
+    if not token:
+        raise EnvironmentError("APPSCRIPT_TOKEN environment variable is not set")
+    return url, token
+
+
+def _request_with_retries(
+    method: str,
+    url: str,
+    headers: dict[str, str],
+    **kwargs: Any,
+) -> dict[str, Any] | None:
+    """Make an HTTP request with exponential backoff retries."""
+    for attempt in range(_MAX_RETRIES):
+        try:
+            resp = requests.request(
+                method, url, headers=headers, timeout=_TIMEOUT_SECS, **kwargs
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except requests.RequestException as exc:
+            wait = 2**attempt
+            logger.warning(
+                "Apps Script request failed (attempt %d/%d): %s — retrying in %ds",
+                attempt + 1,
+                _MAX_RETRIES,
+                exc,
+                wait,
+            )
+            if attempt < _MAX_RETRIES - 1:
+                time.sleep(wait)
+
+    logger.error("Apps Script request failed after %d retries", _MAX_RETRIES)
+    return None
+
+
+def post_data(sheet: str, rows: list[dict[str, Any]]) -> bool:
+    """POST data rows to an Apps Script upsert endpoint.
+
+    Returns True on success, False on failure.
+    """
+    url, token = _get_config()
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "action": "upsert",
+        "sheet": sheet,
+        "rows": rows,
+    }
+
+    result = _request_with_retries("POST", url, headers=headers, json=payload)
+    if result is None:
+        return False
+
+    if result.get("status") != "ok":
+        logger.error("Apps Script upsert error: %s", result.get("error", "unknown"))
+        return False
+
+    logger.info("Posted %d rows to sheet '%s'", len(rows), sheet)
+    return True
+
+
+def get_data(action: str, ticker: str | None = None) -> list[dict[str, Any]]:
+    """GET data from an Apps Script read endpoint.
+
+    Returns a list of row dicts, or an empty list on failure.
+    """
+    url, token = _get_config()
+    headers = {
+        "Authorization": f"Bearer {token}",
+    }
+    params: dict[str, str] = {"action": action}
+    if ticker:
+        params["ticker"] = ticker
+
+    result = _request_with_retries("GET", url, headers=headers, params=params)
+    if result is None:
+        return []
+
+    return result.get("data", [])

--- a/scripts/datasets/fetch.py
+++ b/scripts/datasets/fetch.py
@@ -1,0 +1,148 @@
+"""Entry point for the financial data pipeline.
+
+Orchestrates ticker discovery, Yahoo Finance data fetching, sector metric
+extraction, and pushing results to Google Sheets via Apps Script.
+"""
+
+import logging
+import sys
+from typing import Any
+
+import appscript
+from metrics import banking, consumer, mining, telco
+from providers import yahoo
+from tickers import TickerInfo, get_active_tickers
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+# Map sector names to their metric extractor modules.
+_SECTOR_MODULES: dict[str, Any] = {
+    "Banking": banking,
+    "Consumer": consumer,
+    "Telco": telco,
+    "Mining": mining,
+}
+
+
+def _build_ticker_rows(tickers: dict[str, TickerInfo]) -> list[dict[str, Any]]:
+    """Convert ticker info dict to rows suitable for the tickers sheet."""
+    return [
+        {
+            "ticker": code,
+            "name": info.name,
+            "sector": info.sector,
+            "board": info.board,
+            "status": info.status,
+        }
+        for code, info in sorted(tickers.items())
+    ]
+
+
+def _flatten_financials(ticker: str, data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten Yahoo Finance data into rows for the financials sheet."""
+    rows: list[dict[str, Any]] = []
+
+    # Key statistics and financial data as a single summary row.
+    summary = {"ticker": ticker}
+    summary.update(data.get("keyStatistics", {}))
+    summary.update(data.get("financialData", {}))
+    rows.append(summary)
+
+    # Income statement rows.
+    for stmt in data.get("incomeStatements", []):
+        row = {"ticker": ticker, "statementType": "income"}
+        row.update(stmt)
+        rows.append(row)
+
+    # Balance sheet rows.
+    for sheet in data.get("balanceSheets", []):
+        row = {"ticker": ticker, "statementType": "balanceSheet"}
+        row.update(sheet)
+        rows.append(row)
+
+    return rows
+
+
+def main() -> None:
+    """Run the full data pipeline."""
+    logger.info("Starting financial data pipeline")
+
+    # 1. Get active tickers.
+    tickers = get_active_tickers()
+    if not tickers:
+        logger.error("No tickers found — aborting")
+        sys.exit(1)
+
+    logger.info("Found %d active tickers", len(tickers))
+
+    # Push ticker list to the tickers sheet.
+    ticker_rows = _build_ticker_rows(tickers)
+    appscript.post_data("tickers", ticker_rows)
+
+    # 2. Fetch financials from Yahoo Finance.
+    success = 0
+    failed = 0
+    skipped = 0
+    all_financials: dict[str, dict[str, Any]] = {}
+
+    for ticker in sorted(tickers):
+        logger.info("Fetching %s...", ticker)
+        data = yahoo.fetch(ticker)
+        if data is None:
+            failed += 1
+            continue
+
+        all_financials[ticker] = data
+        flat_rows = _flatten_financials(ticker, data)
+        if appscript.post_data("financials", flat_rows):
+            success += 1
+        else:
+            failed += 1
+
+    # 3. Compute derivable sector metrics.
+    metrics_success = 0
+    metrics_skipped = 0
+
+    for ticker, info in sorted(tickers.items()):
+        sector_module = _SECTOR_MODULES.get(info.sector)
+        if sector_module is None:
+            metrics_skipped += 1
+            continue
+
+        financials = all_financials.get(ticker)
+        if financials is None:
+            metrics_skipped += 1
+            continue
+
+        metrics = sector_module.extract(ticker, financials)
+        if metrics:
+            if appscript.post_data("sector_metrics", metrics):
+                metrics_success += 1
+            else:
+                failed += 1
+        else:
+            metrics_skipped += 1
+
+    # 4. Report summary.
+    logger.info("=" * 50)
+    logger.info("Pipeline complete")
+    logger.info("  Financials — success: %d, failed: %d", success, failed)
+    logger.info(
+        "  Sector metrics — posted: %d, skipped: %d",
+        metrics_success,
+        metrics_skipped,
+    )
+    logger.info("  Total tickers: %d", len(tickers))
+    logger.info("=" * 50)
+
+    if failed > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/datasets/fetch.py
+++ b/scripts/datasets/fetch.py
@@ -87,7 +87,6 @@ def main() -> None:
     # 2. Fetch financials from Yahoo Finance.
     success = 0
     failed = 0
-    skipped = 0
     all_financials: dict[str, dict[str, Any]] = {}
 
     for ticker in sorted(tickers):

--- a/scripts/datasets/metrics/__init__.py
+++ b/scripts/datasets/metrics/__init__.py
@@ -1,0 +1,1 @@
+"""Sector-specific metric extractors."""

--- a/scripts/datasets/metrics/banking.py
+++ b/scripts/datasets/metrics/banking.py
@@ -1,0 +1,26 @@
+"""Banking sector metric extractors: CAR, NIM, NPL, LDR."""
+
+from typing import Any
+
+
+def extract(ticker: str, financials: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract banking-specific metrics.
+
+    CAR, NIM, NPL, and LDR are not derivable from standard financial
+    statements — they require regulatory filings. All are marked as manual.
+    """
+    metrics: list[dict[str, Any]] = []
+
+    for metric_name in ("CAR", "NIM", "NPL", "LDR"):
+        metrics.append(
+            {
+                "ticker": ticker,
+                "metric": metric_name,
+                "value": None,
+                "source": "manual",
+                "year": None,
+                "quarter": None,
+            }
+        )
+
+    return metrics

--- a/scripts/datasets/metrics/base.py
+++ b/scripts/datasets/metrics/base.py
@@ -1,0 +1,39 @@
+"""Base metric definitions and sector-to-metric mapping."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class MetricDefinition:
+    """Defines a sector-specific financial metric."""
+
+    name: str
+    source: str  # "auto" (derivable from financials) or "manual" (requires manual input)
+    description: str
+
+
+# Mapping of sector name to its specific metrics.
+SECTOR_METRICS: dict[str, list[MetricDefinition]] = {
+    "Banking": [
+        MetricDefinition("CAR", "manual", "Capital Adequacy Ratio"),
+        MetricDefinition("NIM", "manual", "Net Interest Margin"),
+        MetricDefinition("NPL", "manual", "Non-Performing Loan ratio"),
+        MetricDefinition("LDR", "manual", "Loan-to-Deposit Ratio"),
+    ],
+    "Consumer": [
+        MetricDefinition("SSSG", "manual", "Same-Store Sales Growth"),
+        MetricDefinition("GPM", "auto", "Gross Profit Margin (gross profit / revenue)"),
+    ],
+    "Telco": [
+        MetricDefinition("ARPU", "manual", "Average Revenue Per User"),
+    ],
+    "Mining": [
+        MetricDefinition("ASP", "manual", "Average Selling Price"),
+        MetricDefinition("StrippingRatio", "manual", "Stripping ratio (overburden / ore)"),
+    ],
+}
+
+
+def get_sector_metrics(sector: str) -> list[MetricDefinition]:
+    """Return metric definitions for a sector, or an empty list if none defined."""
+    return SECTOR_METRICS.get(sector, [])

--- a/scripts/datasets/metrics/consumer.py
+++ b/scripts/datasets/metrics/consumer.py
@@ -1,0 +1,55 @@
+"""Consumer sector metric extractors: SSSG, GPM."""
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def extract(ticker: str, financials: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract consumer-specific metrics.
+
+    GPM (Gross Profit Margin) is derivable from income statement data.
+    SSSG (Same-Store Sales Growth) requires company-specific disclosures.
+    """
+    metrics: list[dict[str, Any]] = []
+
+    # SSSG is always manual — not available in standard financials.
+    metrics.append(
+        {
+            "ticker": ticker,
+            "metric": "SSSG",
+            "value": None,
+            "source": "manual",
+            "year": None,
+            "quarter": None,
+        }
+    )
+
+    # GPM: derive from income statement gross profit / revenue.
+    for stmt in financials.get("incomeStatements", []):
+        revenue = stmt.get("totalRevenue")
+        gross_profit = stmt.get("grossProfit")
+        if revenue and gross_profit and revenue != 0:
+            gpm = gross_profit / revenue
+
+            year, quarter = _parse_period(stmt.get("endDate"))
+            metrics.append(
+                {
+                    "ticker": ticker,
+                    "metric": "GPM",
+                    "value": round(gpm, 4),
+                    "source": "auto",
+                    "year": year,
+                    "quarter": quarter,
+                }
+            )
+
+    return metrics
+
+
+def _parse_period(end_date: int | None) -> tuple[int | None, int | None]:
+    """Convert Unix timestamp to (year, quarter)."""
+    if end_date is None:
+        return None, None
+    dt = datetime.fromtimestamp(end_date, tz=timezone.utc)
+    quarter = (dt.month - 1) // 3 + 1
+    return dt.year, quarter

--- a/scripts/datasets/metrics/mining.py
+++ b/scripts/datasets/metrics/mining.py
@@ -1,0 +1,29 @@
+"""Mining sector metric extractors: ASP, stripping ratio."""
+
+from typing import Any
+
+
+def extract(ticker: str, financials: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract mining-specific metrics.
+
+    ASP (Average Selling Price) and stripping ratio require company-specific
+    operational data not available in standard financial statements.
+    """
+    return [
+        {
+            "ticker": ticker,
+            "metric": "ASP",
+            "value": None,
+            "source": "manual",
+            "year": None,
+            "quarter": None,
+        },
+        {
+            "ticker": ticker,
+            "metric": "StrippingRatio",
+            "value": None,
+            "source": "manual",
+            "year": None,
+            "quarter": None,
+        },
+    ]

--- a/scripts/datasets/metrics/telco.py
+++ b/scripts/datasets/metrics/telco.py
@@ -1,0 +1,21 @@
+"""Telco sector metric extractors: ARPU."""
+
+from typing import Any
+
+
+def extract(ticker: str, financials: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract telco-specific metrics.
+
+    ARPU (Average Revenue Per User) requires operator-specific disclosures
+    and is not derivable from standard financial statements.
+    """
+    return [
+        {
+            "ticker": ticker,
+            "metric": "ARPU",
+            "value": None,
+            "source": "manual",
+            "year": None,
+            "quarter": None,
+        }
+    ]

--- a/scripts/datasets/providers/__init__.py
+++ b/scripts/datasets/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Data providers for fetching financial data from external sources."""

--- a/scripts/datasets/providers/idx_listing.py
+++ b/scripts/datasets/providers/idx_listing.py
@@ -1,0 +1,72 @@
+"""IDX listing API client for discovering active tickers."""
+
+import logging
+from dataclasses import dataclass
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+IDX_STOCK_DATA_URL = "https://www.idx.co.id/primary/StockData/GetStockData"
+
+# IDX API requires a browser-like user agent to avoid 403 responses.
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/json",
+    "Referer": "https://www.idx.co.id/en/market-data/stocks/",
+}
+
+
+@dataclass
+class IDXStock:
+    """Represents a stock listed on IDX."""
+
+    code: str
+    name: str
+    sector: str
+    board: str
+    status: str
+
+
+def fetch_active_stocks() -> list[IDXStock]:
+    """Fetch all active (non-suspended) stocks from IDX API.
+
+    Returns an empty list and logs a warning on API failure.
+    """
+    try:
+        params = {
+            "start": 0,
+            "length": 9999,
+        }
+        resp = requests.get(
+            IDX_STOCK_DATA_URL,
+            params=params,
+            headers=_HEADERS,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        stocks: list[IDXStock] = []
+        for item in data.get("data", []):
+            status = item.get("Status", "")
+            if status == "Suspend":
+                continue
+            stocks.append(
+                IDXStock(
+                    code=item.get("Code", ""),
+                    name=item.get("Name", ""),
+                    sector=item.get("SectorName", ""),
+                    board=item.get("ListingBoard", ""),
+                    status=status,
+                )
+            )
+        logger.info("Fetched %d active stocks from IDX", len(stocks))
+        return stocks
+
+    except (requests.RequestException, ValueError, KeyError) as exc:
+        logger.warning("IDX API fetch failed: %s", exc)
+        return []

--- a/scripts/datasets/providers/yahoo.py
+++ b/scripts/datasets/providers/yahoo.py
@@ -1,0 +1,182 @@
+"""Yahoo Finance data fetcher for IDX stocks."""
+
+import logging
+import time
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://query1.finance.yahoo.com/v10/finance/quoteSummary"
+
+_MODULES = [
+    "incomeStatementHistory",
+    "incomeStatementHistoryQuarterly",
+    "balanceSheetHistory",
+    "balanceSheetHistoryQuarterly",
+    "defaultKeyStatistics",
+    "financialData",
+]
+
+_MAX_RETRIES = 3
+_RATE_LIMIT_SECS = 1.0
+
+# Track last request time for rate limiting across calls.
+_last_request_time: float = 0.0
+
+
+def _to_yahoo_ticker(ticker: str) -> str:
+    """Convert IDX ticker to Yahoo Finance format (append .JK suffix)."""
+    return f"{ticker}.JK"
+
+
+def _get_with_retries(url: str, params: dict[str, str]) -> dict[str, Any] | None:
+    """GET request with exponential backoff retries and rate limiting."""
+    global _last_request_time
+
+    for attempt in range(_MAX_RETRIES):
+        # Rate limiting: wait at least 1 second between requests.
+        elapsed = time.monotonic() - _last_request_time
+        if elapsed < _RATE_LIMIT_SECS:
+            time.sleep(_RATE_LIMIT_SECS - elapsed)
+
+        try:
+            _last_request_time = time.monotonic()
+            resp = requests.get(url, params=params, timeout=30)
+            resp.raise_for_status()
+            return resp.json()
+        except requests.RequestException as exc:
+            wait = 2**attempt
+            logger.warning(
+                "Yahoo Finance request failed (attempt %d/%d): %s — retrying in %ds",
+                attempt + 1,
+                _MAX_RETRIES,
+                exc,
+                wait,
+            )
+            time.sleep(wait)
+
+    return None
+
+
+def _safe_get(obj: Any, key: str) -> Any:
+    """Safely extract a value from a Yahoo Finance data object.
+
+    Yahoo wraps values in dicts like {"raw": 123, "fmt": "123"}.
+    """
+    if obj is None:
+        return None
+    val = obj.get(key)
+    if isinstance(val, dict):
+        return val.get("raw")
+    return val
+
+
+def _extract_income_statements(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract annual and quarterly income statement data."""
+    statements: list[dict[str, Any]] = []
+
+    for module_key in ("incomeStatementHistory", "incomeStatementHistoryQuarterly"):
+        module = result.get(module_key, {})
+        period = "annual" if "Quarterly" not in module_key else "quarterly"
+
+        for stmt in module.get("incomeStatementHistory", []):
+            statements.append(
+                {
+                    "period": period,
+                    "endDate": _safe_get(stmt, "endDate"),
+                    "totalRevenue": _safe_get(stmt, "totalRevenue"),
+                    "netIncome": _safe_get(stmt, "netIncome"),
+                    "operatingIncome": _safe_get(stmt, "operatingIncome"),
+                    "costOfRevenue": _safe_get(stmt, "costOfRevenue"),
+                    "grossProfit": _safe_get(stmt, "grossProfit"),
+                }
+            )
+
+    return statements
+
+
+def _extract_balance_sheets(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract annual and quarterly balance sheet data."""
+    sheets: list[dict[str, Any]] = []
+
+    for module_key in ("balanceSheetHistory", "balanceSheetHistoryQuarterly"):
+        module = result.get(module_key, {})
+        period = "annual" if "Quarterly" not in module_key else "quarterly"
+
+        for stmt in module.get("balanceSheetStatements", []):
+            sheets.append(
+                {
+                    "period": period,
+                    "endDate": _safe_get(stmt, "endDate"),
+                    "totalAssets": _safe_get(stmt, "totalAssets"),
+                    "totalStockholderEquity": _safe_get(
+                        stmt, "totalStockholderEquity"
+                    ),
+                    "totalDebt": _safe_get(stmt, "longTermDebt"),
+                    "totalCurrentAssets": _safe_get(stmt, "totalCurrentAssets"),
+                    "totalCurrentLiabilities": _safe_get(
+                        stmt, "totalCurrentLiabilities"
+                    ),
+                }
+            )
+
+    return sheets
+
+
+def _extract_key_statistics(result: dict[str, Any]) -> dict[str, Any]:
+    """Extract key statistics (PER, PBV, etc.)."""
+    stats = result.get("defaultKeyStatistics", {})
+    return {
+        "trailingPE": _safe_get(stats, "trailingPE") or _safe_get(stats, "trailingPe"),
+        "forwardPE": _safe_get(stats, "forwardPE") or _safe_get(stats, "forwardPe"),
+        "priceToBook": _safe_get(stats, "priceToBook"),
+        "enterpriseValue": _safe_get(stats, "enterpriseValue"),
+    }
+
+
+def _extract_financial_data(result: dict[str, Any]) -> dict[str, Any]:
+    """Extract financial data (ROE, ROA, ratios)."""
+    fin = result.get("financialData", {})
+    return {
+        "returnOnEquity": _safe_get(fin, "returnOnEquity"),
+        "returnOnAssets": _safe_get(fin, "returnOnAssets"),
+        "currentRatio": _safe_get(fin, "currentRatio"),
+        "debtToEquity": _safe_get(fin, "debtToEquity"),
+        "revenueGrowth": _safe_get(fin, "revenueGrowth"),
+        "earningsGrowth": _safe_get(fin, "earningsGrowth"),
+        "currentPrice": _safe_get(fin, "currentPrice"),
+    }
+
+
+def fetch(ticker: str) -> dict[str, Any] | None:
+    """Fetch financial data for an IDX ticker from Yahoo Finance.
+
+    Returns a dict with income statements, balance sheets, key statistics,
+    and financial data, or None on failure.
+    """
+    yahoo_ticker = _to_yahoo_ticker(ticker)
+    params = {
+        "modules": ",".join(_MODULES),
+    }
+    url = f"{_BASE_URL}/{yahoo_ticker}"
+
+    data = _get_with_retries(url, params)
+    if data is None:
+        logger.error("Failed to fetch data for %s after %d retries", ticker, _MAX_RETRIES)
+        return None
+
+    try:
+        result = data["quoteSummary"]["result"][0]
+    except (KeyError, IndexError, TypeError):
+        logger.error("Unexpected response structure for %s", ticker)
+        return None
+
+    return {
+        "ticker": ticker,
+        "incomeStatements": _extract_income_statements(result),
+        "balanceSheets": _extract_balance_sheets(result),
+        "keyStatistics": _extract_key_statistics(result),
+        "financialData": _extract_financial_data(result),
+    }

--- a/scripts/datasets/requirements.txt
+++ b/scripts/datasets/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/scripts/datasets/requirements.txt
+++ b/scripts/datasets/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests>=2.31,<3

--- a/scripts/datasets/tickers.py
+++ b/scripts/datasets/tickers.py
@@ -1,0 +1,74 @@
+"""Dynamic ticker list from IDX API with fallback to static config."""
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from providers.idx_listing import fetch_active_stocks
+
+logger = logging.getLogger(__name__)
+
+# Path to sectors.json relative to repo root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SECTORS_JSON = _REPO_ROOT / "configs" / "sectors.json"
+
+
+@dataclass
+class TickerInfo:
+    """Metadata for a listed stock."""
+
+    name: str
+    sector: str
+    board: str
+    status: str
+
+
+def get_active_tickers() -> dict[str, TickerInfo]:
+    """Get active tickers, trying IDX API first then falling back to sectors.json.
+
+    Returns a dict mapping ticker code to TickerInfo.
+    """
+    tickers = _fetch_from_idx()
+    if tickers:
+        return tickers
+
+    logger.info("Falling back to static ticker list from %s", _SECTORS_JSON)
+    return _load_from_sectors_json()
+
+
+def _fetch_from_idx() -> dict[str, TickerInfo]:
+    """Fetch active tickers from IDX API."""
+    stocks = fetch_active_stocks()
+    if not stocks:
+        return {}
+
+    return {
+        stock.code: TickerInfo(
+            name=stock.name,
+            sector=stock.sector,
+            board=stock.board,
+            status=stock.status,
+        )
+        for stock in stocks
+        if stock.code
+    }
+
+
+def _load_from_sectors_json() -> dict[str, TickerInfo]:
+    """Load tickers from the static sectors.json config file."""
+    try:
+        data = json.loads(_SECTORS_JSON.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        logger.error("Failed to load %s: %s", _SECTORS_JSON, exc)
+        return {}
+
+    return {
+        ticker: TickerInfo(
+            name=ticker,
+            sector=sector,
+            board="",
+            status="Active",
+        )
+        for ticker, sector in data.items()
+    }


### PR DESCRIPTION
## Issue

N/A

## Summary

- Add Python data pipeline (`scripts/datasets/`) that fetches financial data from Yahoo Finance, discovers active tickers from IDX API, extracts sector-specific metrics, and pushes data to Google Sheets via Apps Script
- Add Apps Script endpoints (`scripts/appscript/Code.gs`) with doGet (read) and doPost (token-protected write) for Google Sheets storage
- Add GitHub Actions workflow (`.github/workflows/datasets.yml`) — weekly cron (Monday 6am UTC) + manual trigger
- Add Go backend integration: `domain/dataset` (entities + repository interface), `infra/dataset` (HTTP client with 24h file cache, 1MB response limit, atomic writes, graceful degradation), `presenter/dataset` (handler + DTOs)
- Wire dataset handler into `app.go`, inject `appscriptURL` via ldflags, update release workflow LDFLAGS
- Add Python 3.13 to mise tooling, add `dataset-setup` and `dataset-fetch` Makefile targets

## Test Plan

- [ ] Linter passes (`make lint`)
- [ ] Go tests pass (`make test-go`) — 8 dataset client tests covering cache, graceful degradation, size limits, malformed JSON, HTTP errors
- [ ] Python syntax valid (`python3 -m py_compile scripts/datasets/fetch.py`)
- [ ] App builds with empty APPSCRIPT_URL (`make build`) — graceful degradation, no errors
- [ ] Manual: `APPSCRIPT_URL=... APPSCRIPT_TOKEN=... make dataset-fetch` pushes data to Google Sheets
- [ ] Manual: Hit `?action=financials&ticker=BBCA` on deployed Apps Script → JSON response

## Notes

- `APPSCRIPT_URL` (GitHub var) and `APPSCRIPT_TOKEN` (GitHub secret) must be configured before the pipeline or release builds work
- Sector metrics (CAR, NIM, NPL, SSSG, ARPU) are marked as manual source — they require regulatory/company filings not available in Yahoo Finance
- The pipeline is designed for weekly cadence to stay within Apps Script free tier quotas (90 min/day)